### PR TITLE
moved phpunit.xml.dist to the root and fixed its content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ php:
 before_script:
   - wget http://getcomposer.org/composer.phar
   - php composer.phar install
-script: phpunit -c tests/ tests/
+script: phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,18 +9,18 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="bootstrap.php"
+         bootstrap="tests/bootstrap.php"
 >
 <testsuites>
   <testsuite name="EmailValidator Test Suite">
-    <directory>./tests/egulias/Tests/*.Test.php</directory>
+    <directory>./tests/egulias/Tests/</directory>
     <exclude>./vendor/</exclude>
   </testsuite>
 </testsuites>
 
 <filter>
   <blacklist>
-    <directory>../vendor</directory>
+    <directory>./vendor</directory>
   </blacklist>
 </filter>
 </phpunit>


### PR DESCRIPTION
It's a best practice to put the `phpunit.xml.dist` file under the root directory to ease running the tests by just running `phpunit`
