### PR TITLE
Change DNS validation to default to true instead of false

### DIFF
--- a/src/Egulias/EmailValidator/EmailValidator.php
+++ b/src/Egulias/EmailValidator/EmailValidator.php
@@ -86,7 +86,7 @@ class EmailValidator
             return false;
         }
 
-        $dns = false;
+        $dns = true;
         if ($checkDNS) {
             $dns = $this->checkDNS();
         }


### PR DESCRIPTION
There shouldn't be a dependency on the checkDNS() method in order to
validate strict = true. We should only be concerned about the DNS if the
library is specifically told to check DNS, so we default the DNS
variable to true and then set it to false if $checkDNS is set to true and
checkDNS() returns false.
