### PR TITLE
Fixed the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "extra": {
     "branch-alias": {
-      "dev-master": "1.0.x-dev"
+      "dev-master": "1.3.x-dev"
     }
   },
   "require":      {


### PR DESCRIPTION
the latest release being 1.2.2, aliasing as 1.0.x-dev does not make sense
