### PR TITLE
Tests: Double dots in domain part, German Umlauts as valid e-mail

### DIFF
--- a/tests/egulias/Tests/EmailValidator/EmailValidatorTest.php
+++ b/tests/egulias/Tests/EmailValidator/EmailValidatorTest.php
@@ -55,6 +55,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
             array('"test\ test"@iana.org'),
             array('""@iana.org'),
             array('"\""@iana.org'),
+            array('müller@möller.de'),
         );
     }
 
@@ -110,6 +111,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
             array('test@iana/icann.org'),
             array('test@foo;bar.com'),
             array('test;123@foobar.com'),
+            array('test@example..com'),
         );
     }
 


### PR DESCRIPTION
Only to prevent regression.