### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ With the help of
 Run the command below to install via Composer
 
 ```shell
-composer require egulias/email-validator
+composer require egulias/email-validator "~1.2"
 ```
 
 ##Usage##


### PR DESCRIPTION
Given that Composer will install the latest version of a package
matching the stability restrictions that apply to project, users can
get an undesired version of package when they don't specify a version
constraint.