### PR TITLE
Allow for escaped quote in quoted text

### DIFF
--- a/src/Egulias/EmailValidator/Parser/LocalPart.php
+++ b/src/Egulias/EmailValidator/Parser/LocalPart.php
@@ -92,6 +92,9 @@ class LocalPart extends Parser
                 $this->warnings[CFWSWithFWS::CODE] = new CFWSWithFWS();
                 $setSpecialsWarning = false;
             }
+            if ($this->lexer->token['type'] === EmailLexer::S_BACKSLASH && $this->lexer->isNextToken(EmailLexer::S_DQUOTE)) {
+                $this->lexer->moveNext();
+            }
 
             $this->lexer->moveNext();
 

--- a/tests/egulias/Tests/EmailValidator/Validation/RFCValidationTest.php
+++ b/tests/egulias/Tests/EmailValidator/Validation/RFCValidationTest.php
@@ -85,6 +85,7 @@ class RFCValidationTest extends \PHPUnit_Framework_TestCase
             ['"user,name"@example.com'],
             ['"user name"@example.com'],
             ['"user@name"@example.com'],
+            ['"user\"name"@example.com'],
             ['"\a"@iana.org'],
             ['"test\ test"@iana.org'],
             ['""@iana.org'],


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Email_address#Local_part we should expect an email address like `"very.(),:;<>[]\".VERY.\"very@\\ \"very\".unusual"@strange.example.com`.

I.e. an escaped quote in a quoted text part, currently the local part parser reaches until `"very.(),:;<>[]\`. 