### PR TITLE
fix version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
   },
   "require":      {
     "php": ">= 5.3.3",
-    "doctrine/lexer": "1.0.1"
+    "doctrine/lexer": "^1.0.1"
   },
   "require-dev" :   {
-    "phpunit/phpunit": "4.8.24"
+    "phpunit/phpunit": "^4.8.24"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
At least for the `require` section it doesn't make much sense to rely on a particular patch version.