### PR TITLE
Exclude some dirs and files from repository auto-generated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/documentation export-ignore
+/.* export-ignore
+/phpunit.xml.dist


### PR DESCRIPTION
People that install this library via composer don't need the test stuff, they just need the library itself.
This PR removes the development directories and files from the repository auto-generated ZIP archives.
Since these development files/directories will still be available via `git clone`, Travis is happy, developers are happy, and so are end-users (they won't have unneeded stuff in production machines).

About the documentation: I think that this directory too should be removed from development machines: developers that need it can still do a `git clone` or read it on GitHub.