### PR TITLE
fixed DNSCheckValidation bug

### DIFF
--- a/EmailValidator/Validation/DNSCheckValidation.php
+++ b/EmailValidator/Validation/DNSCheckValidation.php
@@ -28,7 +28,7 @@ class DNSCheckValidation implements EmailValidation
         // use the input to check DNS if we cannot extract something similar to a domain
         $host = $email;
         // Arguable pattern to extract the domain. Not aiming to validate the domain nor the email
-        $pattern = "/^[a-z'0-9]+([._-][a-z'0-9]+)*@([a-z0-9]+([._-][a-z0-9]+)+)+$/";
+        $pattern = "/^[a-z'0-9]+([+._-][a-z'0-9]+)*@([a-z0-9]+([._-][a-z0-9]+)+)+$/";
         if (preg_match($pattern, $email, $result)) {
             $host = $this->extractHost($result);
         }

--- a/Tests/EmailValidator/Validation/DNSCheckValidationTest.php
+++ b/Tests/EmailValidator/Validation/DNSCheckValidationTest.php
@@ -9,10 +9,21 @@ use Egulias\EmailValidator\Warning\NoDNSMXRecord;
 
 class DNSCheckValidationTest extends \PHPUnit_Framework_TestCase
 {
-    public function testValidDNS()
+    public function validEmailsProvider()
+    {
+        return [
+            ["example@example.com"],
+            ["example+foo@example.com"],
+        ];
+    }
+
+    /**
+     * @dataProvider validEmailsProvider
+     */
+    public function testValidDNS($validEmail)
     {
         $validation = new DNSCheckValidation();
-        $this->assertTrue($validation->isValid("example@example.com", new EmailLexer()));
+        $this->assertTrue($validation->isValid($validEmail, new EmailLexer()));
     }
     
     public function testInvalidDNS()


### PR DESCRIPTION
The current `DNSCheckValidation` does not allow the email containing `+`. This is a problem as the Gmail users sometimes use `+` in local-part (e.g. `issei.m7+foo@gmail.com`) to generate multiple account.