### PR TITLE
fixed some problems in DNSCheckValidation

### DIFF
--- a/EmailValidator/Validation/DNSCheckValidation.php
+++ b/EmailValidator/Validation/DNSCheckValidation.php
@@ -27,10 +27,10 @@ class DNSCheckValidation implements EmailValidation
     {
         // use the input to check DNS if we cannot extract something similar to a domain
         $host = $email;
+
         // Arguable pattern to extract the domain. Not aiming to validate the domain nor the email
-        $pattern = "/^[a-z'0-9]+([+._-][a-z'0-9]+)*@([a-z0-9]+([._-][a-z0-9]+)+)+$/";
-        if (preg_match($pattern, $email, $result)) {
-            $host = $this->extractHost($result);
+        if (false !== $lastAtPos = strrpos($email, '@')) {
+            $host = substr($email, $lastAtPos + 1);
         }
 
         return $this->checkDNS($host);
@@ -46,16 +46,6 @@ class DNSCheckValidation implements EmailValidation
         return $this->warnings;
     }
 
-    private function extractHost(array $result)
-    {
-        foreach ($result as $match) {
-            $onlyDomainPattern = "/^([a-z0-9]+([._-][a-z0-9]+))+$/";
-            if (preg_match($onlyDomainPattern, $match, $domainResult)) {
-                return $domainResult[0];
-            }
-        }
-    }
-
     protected function checkDNS($host)
     {
         $Aresult = true;
@@ -63,7 +53,7 @@ class DNSCheckValidation implements EmailValidation
         
         if (!$MXresult) {
             $this->warnings[NoDNSMXRecord::CODE] = new NoDNSMXRecord();
-            $Aresult = checkdnsrr($host, 'A');
+            $Aresult = checkdnsrr($host, 'A') || checkdnsrr($host, 'AAAA');
             if (!$Aresult) {
                 $this->error = new NoDNSRecord();
             }

--- a/Tests/EmailValidator/Validation/DNSCheckValidationTest.php
+++ b/Tests/EmailValidator/Validation/DNSCheckValidationTest.php
@@ -12,8 +12,17 @@ class DNSCheckValidationTest extends \PHPUnit_Framework_TestCase
     public function validEmailsProvider()
     {
         return [
-            ["example@example.com"],
-            ["example+foo@example.com"],
+            // dot-atom
+            ['Abc@example.com'],
+            ['ABC@EXAMPLE.COM'],
+            ['Abc.123@example.com'],
+            ['user+mailbox/department=shipping@example.com'],
+            ['!#$%&\'*+-/=?^_`.{|}~@example.com'],
+
+            // quoted string
+            ['"Abc@def"@example.com'],
+            ['"Fred\ Bloggs"@example.com'],
+            ['"Joe.\\Blow"@example.com'],
         ];
     }
 


### PR DESCRIPTION
Sorry for opening this topic twice in rapid succession.
However I found more further problems in this class as follows:

- The several complex but compliant to RFC email patterns are not supported (e.g.  quoted-string local-part)
  - As [this comment](https://github.com/egulias/EmailValidator/blob/afde3d38746095638e3a4d94926d65ee36f790cb/EmailValidator/Validation/DNSCheckValidation.php#L30), strict check is not required in here. It means just extracting the domain-part using `substr` from last `@` to the EOL is enough.
- upper case email always fails
- lack of IPv6 DNS record check (AAAA record)