### PR TITLE
MultipleValidatorWithAnd now can break out of loop when error occurs

### DIFF
--- a/EmailValidator/Validation/MultipleValidationWithAnd.php
+++ b/EmailValidator/Validation/MultipleValidationWithAnd.php
@@ -3,23 +3,49 @@
 namespace Egulias\EmailValidator\Validation;
 
 use Egulias\EmailValidator\EmailLexer;
+use Egulias\EmailValidator\Exception\InvalidEmail;
 use Egulias\EmailValidator\Validation\Exception\EmptyValidationList;
 
 class MultipleValidationWithAnd implements EmailValidation
 {
+    /**
+     * @var EmailValidation[]
+     */
     private $validations = [];
+
+    /**
+     * @var array
+     */
     private $warnings = [];
+
+    /**
+     * @var InvalidEmail
+     */
     private $error;
-    
-    public function __construct(array $validations)
+
+    /**
+     * @var bool
+     */
+    private $breakIfError;
+
+    /**
+     * @param EmailValidation[] $validations  The validations.
+     * @param bool              $breakIfError If true, it breaks out of validation loop when error occurs,
+     *                                        it means returned MultipleErrors might not contain all causes of errors. (false by default)
+     */
+    public function __construct(array $validations, $breakIfError = false)
     {
         if (count($validations) == 0) {
             throw new EmptyValidationList();
         }
         
         $this->validations = $validations;
+        $this->breakIfError = $breakIfError;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isValid($email, EmailLexer $emailLexer)
     {
         $result = true;
@@ -29,17 +55,27 @@ class MultipleValidationWithAnd implements EmailValidation
             $result = $result && $validation->isValid($email, $emailLexer);
             $this->warnings = array_merge($this->warnings, $validation->getWarnings());
             $errors[] = $validation->getError();
+
+            if (!$result && $this->breakIfError) {
+                break;
+            }
         }
         $this->error = new MultipleErrors($errors);
         
         return $result;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getError()
     {
         return $this->error;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getWarnings()
     {
         return $this->warnings;

--- a/EmailValidator/Validation/MultipleValidationWithAnd.php
+++ b/EmailValidator/Validation/MultipleValidationWithAnd.php
@@ -78,7 +78,7 @@ class MultipleValidationWithAnd implements EmailValidation
 
     private function shouldStop($result)
     {
-        return !$result && $this->mode;
+        return !$result && $this->mode === self::STOP_ON_ERROR;
     }
 
     /**

--- a/EmailValidator/Validation/MultipleValidationWithAnd.php
+++ b/EmailValidator/Validation/MultipleValidationWithAnd.php
@@ -31,7 +31,7 @@ class MultipleValidationWithAnd implements EmailValidation
     private $warnings = [];
 
     /**
-     * @var InvalidEmail
+     * @var MultipleErrors
      */
     private $error;
 

--- a/Tests/EmailValidator/Validation/MultipleValidationWitAndTest.php
+++ b/Tests/EmailValidator/Validation/MultipleValidationWitAndTest.php
@@ -25,7 +25,7 @@ class MultipleValidationWitAndTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Egulias\EmailValidator\Validation\Exception\EmptyValidationList
+     * @expectedException \Egulias\EmailValidator\Validation\Exception\EmptyValidationList
      */
     public function testEmptyListIsNotAllowed()
     {
@@ -76,6 +76,29 @@ class MultipleValidationWitAndTest extends \PHPUnit_Framework_TestCase
         $validation2->expects($this->once())->method("getError")->willReturn($error2);
 
         $multipleValidation = new MultipleValidationWithAnd([$validation1, $validation2]);
+        $multipleValidation->isValid("example@example.com", $lexer);
+        $this->assertEquals($expectedResult, $multipleValidation->getError());
+    }
+
+    public function testBreakOutOfLoopWhenError()
+    {
+        $error = new CommaInDomain();
+
+        $expectedResult = new MultipleErrors([$error]);
+
+        $lexer = $this->getMock("Egulias\\EmailValidator\\EmailLexer");
+
+        $validation1 = $this->getMock("Egulias\\EmailValidator\\Validation\\EmailValidation");
+        $validation1->expects($this->any())->method("isValid")->willReturn(false);
+        $validation1->expects($this->once())->method("getWarnings")->willReturn([]);
+        $validation1->expects($this->once())->method("getError")->willReturn($error);
+
+        $validation2 = $this->getMock("Egulias\\EmailValidator\\Validation\\EmailValidation");
+        $validation2->expects($this->never())->method("isValid");
+        $validation2->expects($this->never())->method("getWarnings");
+        $validation2->expects($this->never())->method("getError");
+
+        $multipleValidation = new MultipleValidationWithAnd([$validation1, $validation2], true);
         $multipleValidation->isValid("example@example.com", $lexer);
         $this->assertEquals($expectedResult, $multipleValidation->getError());
     }

--- a/Tests/EmailValidator/Validation/MultipleValidationWitAndTest.php
+++ b/Tests/EmailValidator/Validation/MultipleValidationWitAndTest.php
@@ -98,7 +98,7 @@ class MultipleValidationWitAndTest extends \PHPUnit_Framework_TestCase
         $validation2->expects($this->never())->method("getWarnings");
         $validation2->expects($this->never())->method("getError");
 
-        $multipleValidation = new MultipleValidationWithAnd([$validation1, $validation2], true);
+        $multipleValidation = new MultipleValidationWithAnd([$validation1, $validation2], MultipleValidationWithAnd::STOP_ON_ERROR);
         $multipleValidation->isValid("example@example.com", $lexer);
         $this->assertEquals($expectedResult, $multipleValidation->getError());
     }


### PR DESCRIPTION
I often use `MultipleValidatorWithAnd` to combine validations such as `RFCValidation`, `DNSCheckValidation`.
In this case, when the preceding RFC check fails, I wanna skip the succeeding DNS check process since that would be costly.

That's why I would like to add a single option for this class to break out of validation loop when one of validations gets failure.