### PR TITLE
Correct PHP example. Add a requirements section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 #EmailValidator
 [![Build Status](https://travis-ci.org/egulias/EmailValidator.png?branch=master)](https://travis-ci.org/egulias/EmailValidator) [![Coverage Status](https://coveralls.io/repos/egulias/EmailValidator/badge.png?branch=master)](https://coveralls.io/r/egulias/EmailValidator?branch=master) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/egulias/EmailValidator/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/egulias/EmailValidator/?branch=master) [![SensioLabsInsight](https://insight.sensiolabs.com/projects/22ba6692-9c02-42e5-a65d-1c5696bfffc6/small.png)](https://insight.sensiolabs.com/projects/22ba6692-9c02-42e5-a65d-1c5696bfffc6)
 =============================
-With the help of
-
-![Powered by PhpStorm](https://www.jetbrains.com/phpstorm/documentation/docs/logo_phpstorm.png)
 
 ##Requirements##
-To load this library, you must have [Composer](https://getcomposer.org) installed and operational. The Spoofchecking validation requires that your PHP system have the [PHP Internationalization Libraries](http://php.net/manual/en/book.intl.php) (also known as PHP Intl) insalled.
+
+ * [Composer](https://getcomposer.org) is required for installation
+ * [Spoofchecking](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/SpoofCheckValidation.php) validation requires that your PHP system have the [PHP Internationalization Libraries](http://php.net/manual/en/book.intl.php) (also known as PHP Intl)
 
 ##Installation##
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 With the help of
 
 ![Powered by PhpStorm](https://www.jetbrains.com/phpstorm/documentation/docs/logo_phpstorm.png)
+
+##Requirements##
+To load this library, you must have [Composer](https://getcomposer.org) installed and operational. The Spoofchecking validation requires that your PHP system have the [PHP Internationalization Libraries](http://php.net/manual/en/book.intl.php) (also known as PHP Intl) insalled.
+
 ##Installation##
 
 Run the command below to install via Composer
@@ -51,8 +55,8 @@ $validator = new EmailValidator();
 $multipleValidations = new MultipleValidationWithAnd([
     new RFCValidation(),
     new DNSCheckValidation()
-])
-$validator->isValid("example@example.com", $multipleValidations) //true
+]);
+$validator->isValid("example@example.com", $multipleValidations); //true
 ```
 
 ###How to extend###


### PR DESCRIPTION
Corrected PHP example for missing semi-colons. Added a new requirements section that explains the need for composer and the need of the PHP Intl library to use the spoof validation.