### PR TITLE
MultipleValidationWithAnd::getError() now returns NULL if no errors

### DIFF
--- a/EmailValidator/Validation/EmailValidation.php
+++ b/EmailValidator/Validation/EmailValidation.php
@@ -9,7 +9,7 @@ use Egulias\EmailValidator\Warning\Warning;
 interface EmailValidation
 {
     /**
-     * Returns true if the given email is fine.
+     * Returns true if the given email is valid.
      *
      * @param string     $email      The email you want to validate.
      * @param EmailLexer $emailLexer The email lexer.
@@ -20,6 +20,8 @@ interface EmailValidation
 
     /**
      * Returns the validation error.
+     *
+     * Be careful about no-error does not necessarily mean email was valid.
      *
      * @return InvalidEmail|null
      */

--- a/EmailValidator/Validation/EmailValidation.php
+++ b/EmailValidator/Validation/EmailValidation.php
@@ -21,8 +21,6 @@ interface EmailValidation
     /**
      * Returns the validation error.
      *
-     * Be careful about no-error does not necessarily mean email was valid.
-     *
      * @return InvalidEmail|null
      */
     public function getError();

--- a/EmailValidator/Validation/EmailValidation.php
+++ b/EmailValidator/Validation/EmailValidation.php
@@ -4,18 +4,31 @@ namespace Egulias\EmailValidator\Validation;
 
 use Egulias\EmailValidator\EmailLexer;
 use Egulias\EmailValidator\Exception\InvalidEmail;
+use Egulias\EmailValidator\Warning\Warning;
 
 interface EmailValidation
 {
+    /**
+     * Returns true if the given email is fine.
+     *
+     * @param string     $email      The email you want to validate.
+     * @param EmailLexer $emailLexer The email lexer.
+     *
+     * @return bool
+     */
     public function isValid($email, EmailLexer $emailLexer);
 
     /**
-     * @return InvalidEmail
+     * Returns the validation error.
+     *
+     * @return InvalidEmail|null
      */
     public function getError();
 
     /**
-     * @return array of Warning
+     * Returns the validation warnings.
+     *
+     * @return Warning[]
      */
     public function getWarnings();
 }

--- a/EmailValidator/Validation/MultipleValidationWithAnd.php
+++ b/EmailValidator/Validation/MultipleValidationWithAnd.php
@@ -78,7 +78,8 @@ class MultipleValidationWithAnd implements EmailValidation
         return $result;
     }
 
-    private function addNewError($possibleError, array $errors) {
+    private function addNewError($possibleError, array $errors)
+    {
         if (null !== $possibleError) {
             $errors[] = $possibleError;
         }

--- a/EmailValidator/Validation/MultipleValidationWithAnd.php
+++ b/EmailValidator/Validation/MultipleValidationWithAnd.php
@@ -3,7 +3,6 @@
 namespace Egulias\EmailValidator\Validation;
 
 use Egulias\EmailValidator\EmailLexer;
-use Egulias\EmailValidator\Exception\InvalidEmail;
 use Egulias\EmailValidator\Validation\Exception\EmptyValidationList;
 
 class MultipleValidationWithAnd implements EmailValidation
@@ -71,8 +70,11 @@ class MultipleValidationWithAnd implements EmailValidation
                 break;
             }
         }
-        $this->error = new MultipleErrors($errors);
-        
+
+        if (!empty(array_filter($errors))) {
+            $this->error = new MultipleErrors($errors);
+        }
+
         return $result;
     }
 

--- a/EmailValidator/Validation/MultipleValidationWithAnd.php
+++ b/EmailValidator/Validation/MultipleValidationWithAnd.php
@@ -64,18 +64,26 @@ class MultipleValidationWithAnd implements EmailValidation
             $emailLexer->reset();
             $result = $result && $validation->isValid($email, $emailLexer);
             $this->warnings = array_merge($this->warnings, $validation->getWarnings());
-            $errors[] = $validation->getError();
+            $errors = $this->addNewError($validation->getError(), $errors);
 
             if ($this->shouldStop($result)) {
                 break;
             }
         }
 
-        if (!empty(array_filter($errors))) {
+        if (!empty($errors)) {
             $this->error = new MultipleErrors($errors);
         }
 
         return $result;
+    }
+
+    private function addNewError($possibleError, array $errors) {
+        if (null !== $possibleError) {
+            $errors[] = $possibleError;
+        }
+
+        return $errors;
     }
 
     private function shouldStop($result)

--- a/Tests/EmailValidator/Validation/MultipleValidationWitAndTest.php
+++ b/Tests/EmailValidator/Validation/MultipleValidationWitAndTest.php
@@ -32,6 +32,19 @@ class MultipleValidationWitAndTest extends \PHPUnit_Framework_TestCase
         new MultipleValidationWithAnd([]);
     }
 
+    public function testValidationIsFine()
+    {
+        $lexer = $this->getMock("Egulias\\EmailValidator\\EmailLexer");
+
+        $validation = $this->getMock("Egulias\\EmailValidator\\Validation\\EmailValidation");
+        $validation->expects($this->any())->method("isValid")->willReturn(true);
+        $validation->expects($this->once())->method("getWarnings")->willReturn([]);
+
+        $multipleValidation = new MultipleValidationWithAnd([$validation]);
+        $this->assertTrue($multipleValidation->isValid("example@example.com", $lexer));
+        $this->assertNull($multipleValidation->getError());
+    }
+
     public function testAccumulatesWarnings()
     {
         $warnings1 = [

--- a/Tests/EmailValidator/Validation/MultipleValidationWitAndTest.php
+++ b/Tests/EmailValidator/Validation/MultipleValidationWitAndTest.php
@@ -32,7 +32,7 @@ class MultipleValidationWitAndTest extends \PHPUnit_Framework_TestCase
         new MultipleValidationWithAnd([]);
     }
 
-    public function testValidationIsFine()
+    public function testValidationIsValid()
     {
         $lexer = $this->getMock("Egulias\\EmailValidator\\EmailLexer");
 


### PR DESCRIPTION
Hi, I'm about to take this topic for three times :)
However MultipleValidationWithAnd is still wrong I think.

EmailValidation::getError() intends to return the NULL if no errors, but this class won't do so.