### PR TITLE
Update composer.json to use the right extension string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "dominicsayers/isemail": "dev-master"
   },
   "suggest": {
-    "ext/php-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+    "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
By using
"ext-intl": "*"
in the require block, the suggestion will be hidden if it is already available. ext/php-intl has few google search results and will confuse less knowledgeable users.

https://github.com/egulias/EmailValidator/issues/128