### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#EmailValidator
+# EmailValidator
 [![Build Status](https://travis-ci.org/egulias/EmailValidator.png?branch=master)](https://travis-ci.org/egulias/EmailValidator) [![Coverage Status](https://coveralls.io/repos/egulias/EmailValidator/badge.png?branch=master)](https://coveralls.io/r/egulias/EmailValidator?branch=master) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/egulias/EmailValidator/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/egulias/EmailValidator/?branch=master) [![SensioLabsInsight](https://insight.sensiolabs.com/projects/22ba6692-9c02-42e5-a65d-1c5696bfffc6/small.png)](https://insight.sensiolabs.com/projects/22ba6692-9c02-42e5-a65d-1c5696bfffc6)
 =============================
 With the help of [PHPStorm](https://www.jetbrains.com/phpstorm/)
 
-##Requirements##
+## Requirements ##
 
  * [Composer](https://getcomposer.org) is required for installation
  * [Spoofchecking](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/SpoofCheckValidation.php) validation requires that your PHP system have the [PHP Internationalization Libraries](http://php.net/manual/en/book.intl.php) (also known as PHP Intl)
 
-##Installation##
+## Installation ##
 
 Run the command below to install via Composer
 
@@ -16,7 +16,7 @@ Run the command below to install via Composer
 composer require egulias/email-validator "~2.1"
 ```
 
-##Getting Started##
+## Getting Started ##
 `EmailValidator`requires you to decide which (or combination of them) validation/s strategy/ies you'd like to follow for each [validation](#available-validations).
 
 A basic example with the RFC validation
@@ -31,7 +31,7 @@ $validator->isValid("example@example.com", new RFCValidation()); //true
 ```
 
 
-###Available validations###
+### Available validations ###
 
 1. [RFCValidation](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/RFCValidation.php)
 2. [NoRFCWarningsValidation](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/NoRFCWarningsValidation.php)
@@ -60,12 +60,12 @@ $multipleValidations = new MultipleValidationWithAnd([
 $validator->isValid("example@example.com", $multipleValidations); //true
 ```
 
-###How to extend###
+### How to extend ###
 
 It's easy! You just need to extend [EmailValidation](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/EmailValidation.php) and you can use your own validation.
 
 
-##Other Contributors##
+## Other Contributors ##
 (You can find current contributors [here](https://github.com/egulias/EmailValidator/graphs/contributors))
 
 As this is a port from another library and work, here are other people related to the previous one:
@@ -74,6 +74,6 @@ As this is a port from another library and work, here are other people related t
 * Josepf Bielawski [@stloyd](http://github.com/stloyd):      		For its first re-work of Dominic's lib
 * Dominic Sayers [@dominicsayers](http://github.com/dominicsayers):  	The original isemail function
 
-##License##
+## License ##
 Released under the MIT License attached with this code.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
