### PR TITLE
DNS check should convert unicode domains first

### DIFF
--- a/EmailValidator/Validation/DNSCheckValidation.php
+++ b/EmailValidator/Validation/DNSCheckValidation.php
@@ -44,7 +44,7 @@ class DNSCheckValidation implements EmailValidation
 
     protected function checkDNS($host)
     {
-        $host = rtrim($host, '.') . '.';
+        $host = rtrim(idn_to_ascii($host), '.') . '.';
 
         $Aresult = true;
         $MXresult = checkdnsrr($host, 'MX');

--- a/EmailValidator/Validation/DNSCheckValidation.php
+++ b/EmailValidator/Validation/DNSCheckValidation.php
@@ -44,7 +44,7 @@ class DNSCheckValidation implements EmailValidation
 
     protected function checkDNS($host)
     {
-        $host = rtrim(idn_to_ascii($host), '.') . '.';
+        $host = rtrim(idn_to_ascii($host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46), '.') . '.';
 
         $Aresult = true;
         $MXresult = checkdnsrr($host, 'MX');

--- a/Tests/EmailValidator/Validation/DNSCheckValidationTest.php
+++ b/Tests/EmailValidator/Validation/DNSCheckValidationTest.php
@@ -24,6 +24,9 @@ class DNSCheckValidationTest extends TestCase
             ['"Abc@def"@example.com'],
             ['"Fred\ Bloggs"@example.com'],
             ['"Joe.\\Blow"@example.com'],
+            
+            // unicide
+            ['ñandu.cl'],
         ];
     }
 


### PR DESCRIPTION
I found this comment on php.net http://php.net/manual/en/function.checkdnsrr.php#113537:

> Before you check domain, you must convert to ascii with idn_to_ascii function:
http://us2.php.net/manual/en/function.idn-to-ascii.php .

```
var_dump(checkdnsrr('ñandu.cl', 'A')); // returns false
var_dump(checkdnsrr(idn_to_ascii('ñandu.cl'), 'A')); // return true
```