### PR TITLE
Prevent some DNS checks when not allowing local domains

### DIFF
--- a/EmailValidator/Validation/Error/LocalEmail.php
+++ b/EmailValidator/Validation/Error/LocalEmail.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Egulias\EmailValidator\Validation\Error;
+
+use Egulias\EmailValidator\Exception\InvalidEmail;
+
+class LocalEmail extends InvalidEmail
+{
+    const CODE = 996;
+    const REASON = "The domain part is a local domain";
+}

--- a/EmailValidator/Validation/NonLocalValidation.php
+++ b/EmailValidator/Validation/NonLocalValidation.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Egulias\EmailValidator\Validation;
+
+use Egulias\EmailValidator\EmailLexer;
+use Egulias\EmailValidator\Exception\InvalidEmail;
+use Egulias\EmailValidator\Validation\Error\LocalEmail;
+use \Spoofchecker;
+
+class NonLocalValidation implements EmailValidation
+{
+    /**
+     * @var InvalidEmail
+     */
+    private $error;
+
+    public function __construct()
+    {
+        if (!class_exists(Spoofchecker::class)) {
+            throw new \LogicException(sprintf('The %s class requires the Intl extension.', __CLASS__));
+        }
+    }
+
+    public function isValid($email, EmailLexer $emailLexer)
+    {
+        // use the input to check DNS if we cannot extract something similar to a domain
+        $host = $email;
+
+        // Arguable pattern to extract the domain. Not aiming to validate the domain nor the email
+        if (false !== $lastAtPos = strrpos($email, '@')) {
+            $host = substr($email, $lastAtPos + 1);
+        }
+
+        if (strpos($host, '.') === false) {
+            $this->error = new LocalEmail();
+        }
+
+        return $this->error === null;
+    }
+
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    public function getWarnings()
+    {
+        return [];
+    }
+}

--- a/EmailValidator/Validation/NonLocalValidation.php
+++ b/EmailValidator/Validation/NonLocalValidation.php
@@ -5,7 +5,6 @@ namespace Egulias\EmailValidator\Validation;
 use Egulias\EmailValidator\EmailLexer;
 use Egulias\EmailValidator\Exception\InvalidEmail;
 use Egulias\EmailValidator\Validation\Error\LocalEmail;
-use \Spoofchecker;
 
 class NonLocalValidation implements EmailValidation
 {
@@ -13,13 +12,6 @@ class NonLocalValidation implements EmailValidation
      * @var InvalidEmail
      */
     private $error;
-
-    public function __construct()
-    {
-        if (!class_exists(Spoofchecker::class)) {
-            throw new \LogicException(sprintf('The %s class requires the Intl extension.', __CLASS__));
-        }
-    }
 
     public function isValid($email, EmailLexer $emailLexer)
     {

--- a/EmailValidator/Validation/NonLocalValidation.php
+++ b/EmailValidator/Validation/NonLocalValidation.php
@@ -23,7 +23,7 @@ class NonLocalValidation implements EmailValidation
             $host = substr($email, $lastAtPos + 1);
         }
 
-        if (strpos($host, '.') === false) {
+        if (false === strpos($host, '.')) {
             $this->error = new LocalEmail();
         }
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ $validator->isValid("example@example.com", new RFCValidation()); //true
 2. [NoRFCWarningsValidation](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/NoRFCWarningsValidation.php)
 3. [DNSCheckValidation](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/DNSCheckValidation.php)
 4. [SpoofCheckValidation](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/SpoofCheckValidation.php)
-5. [MultipleValidationWithAnd](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/MultipleValidationWithAnd.php)
-6. [Your own validation](#how-to-extend)
+5. [NonLocalValidation](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/NonLocalValidation.php)
+6. [MultipleValidationWithAnd](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/MultipleValidationWithAnd.php)
+7. [Your own validation](#how-to-extend)
 
 `MultipleValidationWithAnd`
 

--- a/Tests/EmailValidator/Validation/NonLocalValidationTest.php
+++ b/Tests/EmailValidator/Validation/NonLocalValidationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Egulias\Tests\EmailValidator\Validation;
+
+use Egulias\EmailValidator\EmailLexer;
+use Egulias\EmailValidator\Validation\Error\LocalEmail;
+use Egulias\EmailValidator\Validation\NonLocalValidation;
+use PHPUnit\Framework\TestCase;
+
+class NonLocalValidationTest extends TestCase
+{
+    public function validEmailsProvider()
+    {
+        return [
+            ['test@localhost.org'],
+            ['test.test@example.org'],
+        ];
+    }
+
+    public function invalidEmailsProvider()
+    {
+        return [
+            ['test@localhost'],
+            ['test.test@example'],
+        ];
+    }
+
+    /**
+     * @dataProvider validEmailsProvider
+     */
+    public function testValidNonLocal($validEmail)
+    {
+        $validation = new NonLocalValidation();
+        $this->assertTrue($validation->isValid($validEmail, new EmailLexer()));
+    }
+
+    /**
+     * @dataProvider invalidEmailsProvider
+     */
+    public function testInvalidNonLocal($invalidEmail)
+    {
+        $validation = new NonLocalValidation();
+        $this->assertFalse($validation->isValid($invalidEmail, new EmailLexer()));
+        
+        $expectedError = new LocalEmail();
+        $this->assertEquals($expectedError, $validation->getError());
+    }
+}

--- a/Tests/EmailValidator/Validation/NonLocalValidationTest.php
+++ b/Tests/EmailValidator/Validation/NonLocalValidationTest.php
@@ -42,7 +42,6 @@ class NonLocalValidationTest extends TestCase
         $validation = new NonLocalValidation();
         $this->assertFalse($validation->isValid($invalidEmail, new EmailLexer()));
         
-        $expectedError = new LocalEmail();
-        $this->assertEquals($expectedError, $validation->getError());
+        $this->assertInstanceOf(LocalEmail::class, $validation->getError());
     }
 }


### PR DESCRIPTION
I find quite some of the failed validations I have in production are people just forgetting a dot in the domain part. As I don't allow local domains for the email address this helps in not having to make a more expensive DNS check with a long timeout.