### PR TITLE
DNSCheckValidation requires the Intl extension

### DIFF
--- a/EmailValidator/Validation/DNSCheckValidation.php
+++ b/EmailValidator/Validation/DNSCheckValidation.php
@@ -18,6 +18,13 @@ class DNSCheckValidation implements EmailValidation
      * @var InvalidEmail
      */
     private $error;
+    
+    public function __construct()
+    {
+        if (!extension_loaded('intl')) {
+            throw new \LogicException(sprintf('The %s class requires the Intl extension.', __CLASS__));
+        }
+    }
 
     public function isValid($email, EmailLexer $emailLexer)
     {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ With the help of [PHPStorm](https://www.jetbrains.com/phpstorm/)
 ## Requirements ##
 
  * [Composer](https://getcomposer.org) is required for installation
- * [Spoofchecking](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/SpoofCheckValidation.php) validation requires that your PHP system have the [PHP Internationalization Libraries](https://php.net/manual/en/book.intl.php) (also known as PHP Intl)
+ * [Spoofchecking](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/SpoofCheckValidation.php) and [DNSCheckValidation](https://github.com/egulias/EmailValidator/blob/master/EmailValidator/Validation/DNSCheckValidation.php) validation requires that your PHP system have the [PHP Internationalization Libraries](https://php.net/manual/en/book.intl.php) (also known as PHP Intl)
 
 ## Installation ##
 


### PR DESCRIPTION
DNSCheckValidation requires the Intl extension.

This adds the check and documents the requirement