### PR TITLE
Update MultipleValidationWithAnd.php

### DIFF
--- a/EmailValidator/Validation/MultipleValidationWithAnd.php
+++ b/EmailValidator/Validation/MultipleValidationWithAnd.php
@@ -62,7 +62,8 @@ class MultipleValidationWithAnd implements EmailValidation
         $errors = [];
         foreach ($this->validations as $validation) {
             $emailLexer->reset();
-            $result = $result && $validation->isValid($email, $emailLexer);
+            $validationResult = $validation->isValid($email, $emailLexer);
+            $result = $result && $validationResult;
             $this->warnings = array_merge($this->warnings, $validation->getWarnings());
             $errors = $this->addNewError($validation->getError(), $errors);
 

--- a/Tests/EmailValidator/Validation/MultipleValidationWithAndTest.php
+++ b/Tests/EmailValidator/Validation/MultipleValidationWithAndTest.php
@@ -10,7 +10,7 @@ use Egulias\EmailValidator\Warning\AddressLiteral;
 use Egulias\EmailValidator\Warning\DomainLiteral;
 use PHPUnit\Framework\TestCase;
 
-class MultipleValidationWitAndTest extends TestCase
+class MultipleValidationWithAndTest extends TestCase
 {
     public function testUsesAndLogicalOperation()
     {
@@ -91,6 +91,30 @@ class MultipleValidationWitAndTest extends TestCase
         $validation2->expects($this->once())->method("getError")->willReturn($error2);
 
         $multipleValidation = new MultipleValidationWithAnd([$validation1, $validation2]);
+        $multipleValidation->isValid("example@example.com", $lexer);
+        $this->assertEquals($expectedResult, $multipleValidation->getError());
+    }
+
+    public function testStopsAfterFirstError()
+    {
+        $error1 = new CommaInDomain();
+        $error2 = new NoDomainPart();
+
+        $expectedResult = new MultipleErrors([$error1]);
+
+        $lexer = $this->getMockBuilder("Egulias\\EmailValidator\\EmailLexer")->getMock();
+
+        $validation1 = $this->getMockBuilder("Egulias\\EmailValidator\\Validation\\EmailValidation")->getMock();
+        $validation1->expects($this->any())->method("isValid")->willReturn(true);
+        $validation1->expects($this->once())->method("getWarnings")->willReturn([]);
+        $validation1->expects($this->once())->method("getError")->willReturn($error1);
+
+        $validation2 = $this->getMockBuilder("Egulias\\EmailValidator\\Validation\\EmailValidation")->getMock();
+        $validation2->expects($this->any())->method("isValid")->willReturn(false);
+        $validation2->expects($this->once())->method("getWarnings")->willReturn([]);
+        $validation2->expects($this->once())->method("getError")->willReturn($error2);
+
+        $multipleValidation = new MultipleValidationWithAnd([$validation1, $validation2], MultipleValidationWithAnd::STOP_ON_ERROR);
         $multipleValidation->isValid("example@example.com", $lexer);
         $this->assertEquals($expectedResult, $multipleValidation->getError());
     }

--- a/Tests/EmailValidator/Validation/MultipleValidationWithAndTest.php
+++ b/Tests/EmailValidator/Validation/MultipleValidationWithAndTest.php
@@ -81,12 +81,12 @@ class MultipleValidationWithAndTest extends TestCase
         $lexer = $this->getMockBuilder("Egulias\\EmailValidator\\EmailLexer")->getMock();
 
         $validation1 = $this->getMockBuilder("Egulias\\EmailValidator\\Validation\\EmailValidation")->getMock();
-        $validation1->expects($this->any())->method("isValid")->willReturn(true);
+        $validation1->expects($this->once())->method("isValid")->willReturn(false);
         $validation1->expects($this->once())->method("getWarnings")->willReturn([]);
         $validation1->expects($this->once())->method("getError")->willReturn($error1);
 
         $validation2 = $this->getMockBuilder("Egulias\\EmailValidator\\Validation\\EmailValidation")->getMock();
-        $validation2->expects($this->any())->method("isValid")->willReturn(false);
+        $validation2->expects($this->once())->method("isValid")->willReturn(false);
         $validation2->expects($this->once())->method("getWarnings")->willReturn([]);
         $validation2->expects($this->once())->method("getError")->willReturn($error2);
 
@@ -105,14 +105,14 @@ class MultipleValidationWithAndTest extends TestCase
         $lexer = $this->getMockBuilder("Egulias\\EmailValidator\\EmailLexer")->getMock();
 
         $validation1 = $this->getMockBuilder("Egulias\\EmailValidator\\Validation\\EmailValidation")->getMock();
-        $validation1->expects($this->any())->method("isValid")->willReturn(true);
+        $validation1->expects($this->any())->method("isValid")->willReturn(false);
         $validation1->expects($this->once())->method("getWarnings")->willReturn([]);
         $validation1->expects($this->once())->method("getError")->willReturn($error1);
 
         $validation2 = $this->getMockBuilder("Egulias\\EmailValidator\\Validation\\EmailValidation")->getMock();
         $validation2->expects($this->any())->method("isValid")->willReturn(false);
-        $validation2->expects($this->once())->method("getWarnings")->willReturn([]);
-        $validation2->expects($this->once())->method("getError")->willReturn($error2);
+        $validation2->expects($this->any())->method("getWarnings")->willReturn([]);
+        $validation2->expects($this->any())->method("getError")->willReturn($error2);
 
         $multipleValidation = new MultipleValidationWithAnd([$validation1, $validation2], MultipleValidationWithAnd::STOP_ON_ERROR);
         $multipleValidation->isValid("example@example.com", $lexer);


### PR DESCRIPTION
Hey was debugging my code and i found this issue (not that i need it but i still fixed it anyways).

Fix all validations actually get executed when mode is ALLOW_ALL_ERRORS (1)

if `$result = false`
than `$result && $validator->isValid()` doesnt actually execute this function.  so i put this on a seperate line to execute first.