### PR TITLE
Enabling psalm on php >= 7.1, fixing #125, #168, #169, partially fixing #177

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
       env:
       dist: xenial
     - php: 7.0
-      env:
-        - psalm=yes
       dist: xenial
     - php: 7.1
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,26 +8,38 @@ matrix:
     - php: 5.5
       dist: trusty
     - php: 5.6
+      env:
+        - psalm=yes
       dist: xenial
     - php: 7.0
+      env:
+        - psalm=yes
       dist: xenial
     - php: 7.1
+      env:
+        - psalm=yes
       dist: bionic
     - php: 7.2
+      env:
+        - psalm=yes
       dist: bionic
     - php: 7.3
       dist: bionic
     - php: 7.4
+      env:
+        - psalm=yes
       dist: bionic
 
 install:
   - if [ "$deps" = "low" ]; then composer update --prefer-lowest; else composer install; fi
+  - if [ "$psalm" = "yes" ]; then composer require --dev vimeo/psalm; fi
 
 before_script:
   - mkdir -p build/logs
 
 script:
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+ - if [ "$psalm" = "yes" ]; then vendor/bin/psalm; fi
 
 after_script:
   - php vendor/bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 
 script:
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
- - if [ "$psalm" = "yes" ]; then vendor/bin/psalm; fi
+  - if [ "$psalm" = "yes" ]; then vendor/bin/psalm; fi
 
 after_script:
   - php vendor/bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
       dist: bionic
     - php: 7.3
       dist: bionic
+      env:
+        - psalm=yes
     - php: 7.4
       env:
         - psalm=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
       dist: trusty
     - php: 5.6
       env:
-        - psalm=yes
       dist: xenial
     - php: 7.0
       env:

--- a/EmailValidator/EmailLexer.php
+++ b/EmailValidator/EmailLexer.php
@@ -73,9 +73,15 @@ class EmailLexer extends AbstractLexer
         '\0'   => self::C_NUL,
     );
 
+    /**
+     * @var bool
+     */
     protected $hasInvalidTokens = false;
 
-    protected $previous;
+    /**
+     * @var array
+     */
+    protected $previous = [];
 
     private static $nullToken = [
         'value' => '',
@@ -98,6 +104,9 @@ class EmailLexer extends AbstractLexer
         $this->previous = $this->token = self::$nullToken;
     }
 
+    /**
+     * @return bool
+     */
     public function hasInvalidTokens()
     {
         return $this->hasInvalidTokens;
@@ -107,6 +116,8 @@ class EmailLexer extends AbstractLexer
      * @param string $type
      * @throws \UnexpectedValueException
      * @return boolean
+     *
+     * @psalm-suppress InvalidScalarArgument
      */
     public function find($type)
     {
@@ -122,7 +133,7 @@ class EmailLexer extends AbstractLexer
     /**
      * getPrevious
      *
-     * @return array token
+     * @return array
      */
     public function getPrevious()
     {
@@ -196,6 +207,11 @@ class EmailLexer extends AbstractLexer
         return  self::GENERIC;
     }
 
+    /**
+     * @param string $value
+     *
+     * @return bool
+     */
     protected function isValid($value)
     {
         if (isset($this->charValue[$value])) {

--- a/EmailValidator/EmailLexer.php
+++ b/EmailValidator/EmailLexer.php
@@ -80,9 +80,23 @@ class EmailLexer extends AbstractLexer
 
     /**
      * @var array
+     *
+     * @psalm-var array{value:string, type:null|int, position:int}|array<empty, empty>
      */
     protected $previous = [];
 
+    /**
+     * The last matched/seen token.
+     *
+     * @var array
+     *
+     * @psalm-var array{value:string, type:null|int, position:int}
+     */
+    public $token;
+
+    /**
+     * @psalm-var array{value:'', type:null, position:0}
+     */
     private static $nullToken = [
         'value' => '',
         'type' => null,
@@ -113,7 +127,7 @@ class EmailLexer extends AbstractLexer
     }
 
     /**
-     * @param string $type
+     * @param int $type
      * @throws \UnexpectedValueException
      * @return boolean
      *

--- a/EmailValidator/EmailLexer.php
+++ b/EmailValidator/EmailLexer.php
@@ -95,6 +95,13 @@ class EmailLexer extends AbstractLexer
     public $token;
 
     /**
+     * The next token in the input.
+     *
+     * @var array|null
+     */
+    public $lookahead;
+
+    /**
      * @psalm-var array{value:'', type:null, position:0}
      */
     private static $nullToken = [
@@ -106,6 +113,7 @@ class EmailLexer extends AbstractLexer
     public function __construct()
     {
         $this->previous = $this->token = self::$nullToken;
+        $this->lookahead = null;
     }
 
     /**

--- a/EmailValidator/EmailParser.php
+++ b/EmailValidator/EmailParser.php
@@ -18,9 +18,9 @@ class EmailParser
     const EMAIL_MAX_LENGTH = 254;
 
     /**
-     * @var \SplObjectStorage|array
+     * @var array
      */
-    protected $warnings;
+    protected $warnings = [];
 
     /**
      * @var string
@@ -51,7 +51,6 @@ class EmailParser
         $this->lexer = $lexer;
         $this->localPartParser = new LocalPart($this->lexer);
         $this->domainPartParser = new DomainPart($this->lexer);
-        $this->warnings = new \SplObjectStorage();
     }
 
     /**

--- a/EmailValidator/EmailParser.php
+++ b/EmailValidator/EmailParser.php
@@ -17,11 +17,33 @@ class EmailParser
 {
     const EMAIL_MAX_LENGTH = 254;
 
+    /**
+     * @var \SplObjectStorage|array
+     */
     protected $warnings;
+
+    /**
+     * @var string
+     */
     protected $domainPart = '';
+
+    /**
+     * @var string
+     */
     protected $localPart = '';
+    /**
+     * @var EmailLexer
+     */
     protected $lexer;
+
+    /**
+     * @var LocalPart
+     */
     protected $localPartParser;
+
+    /**
+     * @var DomainPart
+     */
     protected $domainPartParser;
 
     public function __construct(EmailLexer $lexer)
@@ -57,6 +79,9 @@ class EmailParser
         return array('local' => $this->localPart, 'domain' => $this->domainPart);
     }
 
+    /**
+     * @return Warning\Warning[]
+     */
     public function getWarnings()
     {
         $localPartWarnings = $this->localPartParser->getWarnings();
@@ -68,11 +93,17 @@ class EmailParser
         return $this->warnings;
     }
 
+    /**
+     * @return string
+     */
     public function getParsedDomainPart()
     {
         return $this->domainPart;
     }
 
+    /**
+     * @param string $email
+     */
     protected function setParts($email)
     {
         $parts = explode('@', $email);
@@ -80,6 +111,9 @@ class EmailParser
         $this->localPart = $parts[0];
     }
 
+    /**
+     * @return bool
+     */
     protected function hasAtToken()
     {
         $this->lexer->moveNext();

--- a/EmailValidator/EmailValidator.php
+++ b/EmailValidator/EmailValidator.php
@@ -13,12 +13,12 @@ class EmailValidator
     private $lexer;
 
     /**
-     * @var array
+     * @var Warning\Warning[]
      */
-    protected $warnings;
+    protected $warnings = [];
 
     /**
-     * @var InvalidEmail
+     * @var InvalidEmail|null
      */
     protected $error;
 
@@ -58,7 +58,7 @@ class EmailValidator
     }
 
     /**
-     * @return InvalidEmail
+     * @return InvalidEmail|null
      */
     public function getError()
     {

--- a/EmailValidator/Parser/DomainPart.php
+++ b/EmailValidator/Parser/DomainPart.php
@@ -35,6 +35,10 @@ use Egulias\EmailValidator\Warning\TLD;
 class DomainPart extends Parser
 {
     const DOMAIN_MAX_LENGTH = 254;
+
+    /**
+     * @var string
+     */
     protected $domainPart = '';
 
     public function parse($domainPart)
@@ -95,11 +99,18 @@ class DomainPart extends Parser
         }
     }
 
+    /**
+     * @return string
+     */
     public function getDomainPart()
     {
         return $this->domainPart;
     }
 
+    /**
+     * @param string $addressLiteral
+     * @param int $maxGroups
+     */
     public function checkIPV6Tag($addressLiteral, $maxGroups = 8)
     {
         $prev = $this->lexer->getPrevious();
@@ -143,6 +154,9 @@ class DomainPart extends Parser
         }
     }
 
+    /**
+     * @return string
+     */
     protected function doParseDomainPart()
     {
         $domain = '';
@@ -189,7 +203,7 @@ class DomainPart extends Parser
         return $domain;
     }
 
-    private function checkNotAllowedChars($token)
+    private function checkNotAllowedChars(array $token)
     {
         $notAllowed = [EmailLexer::S_BACKSLASH => true, EmailLexer::S_SLASH=> true];
         if (isset($notAllowed[$token['type']])) {
@@ -197,6 +211,9 @@ class DomainPart extends Parser
         }
     }
 
+    /**
+     * @return string|false
+     */
     protected function parseDomainLiteral()
     {
         if ($this->lexer->isNextToken(EmailLexer::S_COLON)) {
@@ -213,6 +230,9 @@ class DomainPart extends Parser
         return $this->doParseDomainLiteral();
     }
 
+    /**
+     * @return string|false
+     */
     protected function doParseDomainLiteral()
     {
         $IPv6TAG = false;
@@ -280,6 +300,11 @@ class DomainPart extends Parser
         return $addressLiteral;
     }
 
+    /**
+     * @param string $addressLiteral
+     *
+     * @return string|false
+     */
     protected function checkIPV4Tag($addressLiteral)
     {
         $matchesIP  = array();
@@ -297,13 +322,13 @@ class DomainPart extends Parser
                 return false;
             }
             // Convert IPv4 part to IPv6 format for further testing
-            $addressLiteral = substr($addressLiteral, 0, $index) . '0:0';
+            $addressLiteral = substr($addressLiteral, 0, (int) $index) . '0:0';
         }
 
         return $addressLiteral;
     }
 
-    protected function checkDomainPartExceptions($prev)
+    protected function checkDomainPartExceptions(array $prev)
     {
         $invalidDomainTokens = array(
             EmailLexer::S_DQUOTE => true,
@@ -338,6 +363,9 @@ class DomainPart extends Parser
         }
     }
 
+    /**
+     * @return bool
+     */
     protected function hasBrackets()
     {
         if ($this->lexer->token['type'] !== EmailLexer::S_OPENBRACKET) {
@@ -353,7 +381,7 @@ class DomainPart extends Parser
         return true;
     }
 
-    protected function checkLabelLength($prev)
+    protected function checkLabelLength(array $prev)
     {
         if ($this->lexer->token['type'] === EmailLexer::S_DOT &&
             $prev['type'] === EmailLexer::GENERIC &&

--- a/EmailValidator/Parser/LocalPart.php
+++ b/EmailValidator/Parser/LocalPart.php
@@ -5,7 +5,6 @@ namespace Egulias\EmailValidator\Parser;
 use Egulias\EmailValidator\Exception\DotAtEnd;
 use Egulias\EmailValidator\Exception\DotAtStart;
 use Egulias\EmailValidator\EmailLexer;
-use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Exception\ExpectingAT;
 use Egulias\EmailValidator\Exception\ExpectingATEXT;
 use Egulias\EmailValidator\Exception\UnclosedQuotedString;

--- a/EmailValidator/Parser/LocalPart.php
+++ b/EmailValidator/Parser/LocalPart.php
@@ -67,6 +67,9 @@ class LocalPart extends Parser
         }
     }
 
+    /**
+     * @return bool
+     */
     protected function parseDoubleQuote()
     {
         $parseAgain = true;
@@ -118,7 +121,10 @@ class LocalPart extends Parser
         return $parseAgain;
     }
 
-    protected function isInvalidToken($token, $closingQuote)
+    /**
+     * @param bool $closingQuote
+     */
+    protected function isInvalidToken(array $token, $closingQuote)
     {
         $forbidden = array(
             EmailLexer::S_COMMA,

--- a/EmailValidator/Parser/Parser.php
+++ b/EmailValidator/Parser/Parser.php
@@ -21,8 +21,19 @@ use Egulias\EmailValidator\Warning\QuotedString;
 
 abstract class Parser
 {
+    /**
+     * @var \Egulias\EmailValidator\Warning\Warning[]
+     */
     protected $warnings = [];
+
+    /**
+     * @var EmailLexer
+     */
     protected $lexer;
+
+    /**
+     * @var int
+     */
     protected $openedParenthesis = 0;
 
     public function __construct(EmailLexer $lexer)
@@ -30,11 +41,17 @@ abstract class Parser
         $this->lexer = $lexer;
     }
 
+    /**
+     * @return \Egulias\EmailValidator\Warning\Warning[]
+     */
     public function getWarnings()
     {
         return $this->warnings;
     }
 
+    /**
+     * @param string $str
+     */
     abstract public function parse($str);
 
     /** @return int */
@@ -80,6 +97,9 @@ abstract class Parser
         }
     }
 
+    /**
+     * @return bool
+     */
     protected function isUnclosedComment()
     {
         try {
@@ -122,6 +142,9 @@ abstract class Parser
         }
     }
 
+    /**
+     * @return bool
+     */
     protected function isFWS()
     {
         if ($this->escaped()) {
@@ -140,6 +163,9 @@ abstract class Parser
         return false;
     }
 
+    /**
+     * @return bool
+     */
     protected function escaped()
     {
         $previous = $this->lexer->getPrevious();
@@ -154,6 +180,9 @@ abstract class Parser
         return false;
     }
 
+    /**
+     * @return bool
+     */
     protected function warnEscaping()
     {
         if ($this->lexer->token['type'] !== EmailLexer::S_BACKSLASH) {
@@ -174,6 +203,11 @@ abstract class Parser
 
     }
 
+    /**
+     * @param bool $hasClosingQuote
+     *
+     * @return bool
+     */
     protected function checkDQUOTE($hasClosingQuote)
     {
         if ($this->lexer->token['type'] !== EmailLexer::S_DQUOTE) {

--- a/EmailValidator/Validation/DNSCheckValidation.php
+++ b/EmailValidator/Validation/DNSCheckValidation.php
@@ -15,10 +15,10 @@ class DNSCheckValidation implements EmailValidation
     private $warnings = [];
 
     /**
-     * @var InvalidEmail
+     * @var InvalidEmail|null
      */
     private $error;
-    
+
     public function __construct()
     {
         if (!extension_loaded('intl')) {
@@ -49,6 +49,11 @@ class DNSCheckValidation implements EmailValidation
         return $this->warnings;
     }
 
+    /**
+     * @param string $host
+     *
+     * @return bool
+     */
     protected function checkDNS($host)
     {
         $variant = INTL_IDNA_VARIANT_2003;

--- a/EmailValidator/Validation/DNSCheckValidation.php
+++ b/EmailValidator/Validation/DNSCheckValidation.php
@@ -21,7 +21,7 @@ class DNSCheckValidation implements EmailValidation
 
     public function __construct()
     {
-        if (!extension_loaded('intl')) {
+        if (!function_exists('idn_to_ascii')) {
             throw new \LogicException(sprintf('The %s class requires the Intl extension.', __CLASS__));
         }
     }

--- a/EmailValidator/Validation/Exception/EmptyValidationList.php
+++ b/EmailValidator/Validation/Exception/EmptyValidationList.php
@@ -6,6 +6,9 @@ use Exception;
 
 class EmptyValidationList extends \InvalidArgumentException
 {
+    /**
+    * @param int $code
+    */
     public function __construct($code = 0, Exception $previous = null)
     {
         parent::__construct("Empty validation list is not allowed", $code, $previous);

--- a/EmailValidator/Validation/MultipleErrors.php
+++ b/EmailValidator/Validation/MultipleErrors.php
@@ -9,16 +9,22 @@ class MultipleErrors extends InvalidEmail
     const CODE = 999;
     const REASON = "Accumulated errors for multiple validations";
     /**
-     * @var array
+     * @var InvalidEmail[]
      */
     private $errors = [];
 
+    /**
+     * @param InvalidEmail[] $errors
+     */
     public function __construct(array $errors)
     {
         $this->errors = $errors;
         parent::__construct();
     }
 
+    /**
+     * @return InvalidEmail[]
+     */
     public function getErrors()
     {
         return $this->errors;

--- a/EmailValidator/Validation/MultipleValidationWithAnd.php
+++ b/EmailValidator/Validation/MultipleValidationWithAnd.php
@@ -30,12 +30,12 @@ class MultipleValidationWithAnd implements EmailValidation
     private $warnings = [];
 
     /**
-     * @var MultipleErrors
+     * @var MultipleErrors|null
      */
     private $error;
 
     /**
-     * @var bool
+     * @var int
      */
     private $mode;
 
@@ -79,6 +79,12 @@ class MultipleValidationWithAnd implements EmailValidation
         return $result;
     }
 
+    /**
+     * @param \Egulias\EmailValidator\Exception\InvalidEmail|null $possibleError
+     * @param \Egulias\EmailValidator\Exception\InvalidEmail[] $errors
+     *
+     * @return \Egulias\EmailValidator\Exception\InvalidEmail[]
+     */
     private function addNewError($possibleError, array $errors)
     {
         if (null !== $possibleError) {
@@ -88,6 +94,11 @@ class MultipleValidationWithAnd implements EmailValidation
         return $errors;
     }
 
+    /**
+     * @param bool $result
+     *
+     * @return bool
+     */
     private function shouldStop($result)
     {
         return !$result && $this->mode === self::STOP_ON_ERROR;

--- a/EmailValidator/Validation/NoRFCWarningsValidation.php
+++ b/EmailValidator/Validation/NoRFCWarningsValidation.php
@@ -9,7 +9,7 @@ use Egulias\EmailValidator\Validation\Error\RFCWarnings;
 class NoRFCWarningsValidation extends RFCValidation
 {
     /**
-     * @var InvalidEmail
+     * @var InvalidEmail|null
      */
     private $error;
 

--- a/EmailValidator/Validation/RFCValidation.php
+++ b/EmailValidator/Validation/RFCValidation.php
@@ -9,7 +9,7 @@ use Egulias\EmailValidator\Exception\InvalidEmail;
 class RFCValidation implements EmailValidation
 {
     /**
-     * @var EmailParser
+     * @var EmailParser|null
      */
     private $parser;
 
@@ -19,7 +19,7 @@ class RFCValidation implements EmailValidation
     private $warnings = [];
 
     /**
-     * @var InvalidEmail
+     * @var InvalidEmail|null
      */
     private $error;
 

--- a/EmailValidator/Validation/SpoofCheckValidation.php
+++ b/EmailValidator/Validation/SpoofCheckValidation.php
@@ -10,7 +10,7 @@ use \Spoofchecker;
 class SpoofCheckValidation implements EmailValidation
 {
     /**
-     * @var InvalidEmail
+     * @var InvalidEmail|null
      */
     private $error;
 
@@ -21,6 +21,9 @@ class SpoofCheckValidation implements EmailValidation
         }
     }
 
+    /**
+     * @psalm-suppress InvalidArgument
+     */
     public function isValid($email, EmailLexer $emailLexer)
     {
         $checker = new Spoofchecker();
@@ -33,6 +36,9 @@ class SpoofCheckValidation implements EmailValidation
         return $this->error === null;
     }
 
+    /**
+     * @return InvalidEmail|null
+     */
     public function getError()
     {
         return $this->error;

--- a/EmailValidator/Warning/QuotedPart.php
+++ b/EmailValidator/Warning/QuotedPart.php
@@ -6,6 +6,10 @@ class QuotedPart extends Warning
 {
     const CODE = 36;
 
+    /**
+     * @param scalar $prevToken
+     * @param scalar $postToken
+     */
     public function __construct($prevToken, $postToken)
     {
         $this->message = "Deprecated Quoted String found between $prevToken and $postToken";

--- a/EmailValidator/Warning/QuotedString.php
+++ b/EmailValidator/Warning/QuotedString.php
@@ -6,6 +6,10 @@ class QuotedString extends Warning
 {
     const CODE = 11;
 
+    /**
+     * @param scalar $prevToken
+     * @param scalar $postToken
+     */
     public function __construct($prevToken, $postToken)
     {
         $this->message = "Quoted String found between $prevToken and $postToken";

--- a/EmailValidator/Warning/Warning.php
+++ b/EmailValidator/Warning/Warning.php
@@ -5,19 +5,36 @@ namespace Egulias\EmailValidator\Warning;
 abstract class Warning
 {
     const CODE = 0;
-    protected $message;
-    protected $rfcNumber;
 
+    /**
+     * @var string
+     */
+    protected $message = '';
+
+    /**
+     * @var int
+     */
+    protected $rfcNumber = 0;
+
+    /**
+     * @return string
+     */
     public function message()
     {
         return $this->message;
     }
 
+    /**
+     * @return int
+     */
     public function code()
     {
         return self::CODE;
     }
 
+    /**
+     * @return int
+     */
     public function RFCNumber()
     {
         return $this->rfcNumber;

--- a/Tests/EmailValidator/Validation/IsEmailFunctionTests.php
+++ b/Tests/EmailValidator/Validation/IsEmailFunctionTests.php
@@ -6,7 +6,6 @@ use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\DNSCheckValidation;
 use Egulias\EmailValidator\Validation\MultipleValidationWithAnd;
 use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
-use Egulias\EmailValidator\Validation\RFCValidation;
 use PHPUnit\Framework\TestCase;
 
 class IsEmailFunctionTests extends TestCase

--- a/Tests/EmailValidator/Validation/MultipleValidationWithAndTest.php
+++ b/Tests/EmailValidator/Validation/MultipleValidationWithAndTest.php
@@ -3,13 +3,11 @@
 namespace Egulias\Tests\EmailValidator\Validation;
 
 use Egulias\EmailValidator\EmailLexer;
-use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Exception\CommaInDomain;
 use Egulias\EmailValidator\Exception\NoDomainPart;
 use Egulias\EmailValidator\Validation\EmailValidation;
 use Egulias\EmailValidator\Validation\MultipleErrors;
 use Egulias\EmailValidator\Validation\MultipleValidationWithAnd;
-use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
 use Egulias\EmailValidator\Validation\RFCValidation;
 use Egulias\EmailValidator\Warning\AddressLiteral;
 use Egulias\EmailValidator\Warning\DomainLiteral;

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
   },
   "require": {
     "php": ">=5.5",
-    "doctrine/lexer": "^1.0.1"
+    "doctrine/lexer": "^1.0.1",
+    "symfony/polyfill-intl-idn": "^1.10"
   },
   "require-dev": {
     "satooshi/php-coveralls": "^1.0.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "symfony/polyfill-intl-idn": "^1.10"
   },
   "require-dev": {
-    "ext-intl": "*",
     "satooshi/php-coveralls": "^1.0.1",
     "phpunit/phpunit": "^4.8.36|^7.5.15",
     "dominicsayers/isemail": "^3.0.7"

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "symfony/polyfill-intl-idn": "^1.10"
   },
   "require-dev": {
+    "ext-intl": "*",
     "satooshi/php-coveralls": "^1.0.1",
     "phpunit/phpunit": "^4.8.36|^7.5.15",
     "dominicsayers/isemail": "^3.0.7"

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.4.12@86e5e50c1bb492045e70f2ebe1da3cad06e4e9b2">
+<files psalm-version="3.8.3@389af1bfc739bfdff3f9e3dc7bd6499aee51a831">
   <file src="EmailValidator/EmailLexer.php">
     <DocblockTypeContradiction occurrences="1">
       <code>self::$nullToken</code>
     </DocblockTypeContradiction>
-  </file>
-  <file src="EmailValidator/Parser/DomainPart.php">
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>null !== $this-&gt;lexer-&gt;token['type']</code>
-    </RedundantConditionGivenDocblockType>
-  </file>
-  <file src="EmailValidator/Parser/LocalPart.php">
-    <RedundantConditionGivenDocblockType occurrences="2">
-      <code>$this-&gt;lexer-&gt;token['type'] !== EmailLexer::S_AT &amp;&amp; null !== $this-&gt;lexer-&gt;token['type']</code>
-      <code>$this-&gt;lexer-&gt;token['type'] !== EmailLexer::S_DQUOTE &amp;&amp; null !== $this-&gt;lexer-&gt;token['type']</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="EmailValidator/Parser/Parser.php">
     <MissingReturnType occurrences="1">

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -10,4 +10,10 @@
       <code>parse</code>
     </MissingReturnType>
   </file>
+  <file src="EmailValidator/Validation/SpoofCheckValidation.php">
+    <UndefinedClass occurrences="2">
+      <code>Spoofchecker</code>
+      <code>Spoofchecker</code>
+    </UndefinedClass>
+  </file>
 </files>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.4.12@86e5e50c1bb492045e70f2ebe1da3cad06e4e9b2">
+  <file src="EmailValidator/EmailLexer.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>self::$nullToken</code>
+    </DocblockTypeContradiction>
+  </file>
+  <file src="EmailValidator/Parser/DomainPart.php">
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>null !== $this-&gt;lexer-&gt;token['type']</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="EmailValidator/Parser/LocalPart.php">
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$this-&gt;lexer-&gt;token['type'] !== EmailLexer::S_AT &amp;&amp; null !== $this-&gt;lexer-&gt;token['type']</code>
+      <code>$this-&gt;lexer-&gt;token['type'] !== EmailLexer::S_DQUOTE &amp;&amp; null !== $this-&gt;lexer-&gt;token['type']</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="EmailValidator/Parser/Parser.php">
+    <MissingReturnType occurrences="1">
+      <code>parse</code>
+    </MissingReturnType>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<psalm
+    requireVoidReturnType="false"
+    totallyTyped="false"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config ./vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="EmailValidator" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+    </issueHandlers>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config ./vendor/vimeo/psalm/config.xsd"
+    errorBaseline="./psalm.baseline.xml"
 >
     <projectFiles>
         <directory name="EmailValidator" />


### PR DESCRIPTION
* re: 210ac3c & da2e0c6, there's an `@psalm-suppress` or two in there rather than a baseline file because the older versions of psalm required for `php < 7` consider the baseline attribute invalid so that'd be best put off until you make the decision to drop support for php 5 in a given release.
* c504af2 only partially resolves #177 because the `SpoofChecker` class isn't polyfilled. The options there would be to find a polyfill just for SpoofChecker, or to fork out the `SpoofCheckValidation` class into a package that explicitly requires `ext-intl:*`
* 6812a28 & 02a6193 were done for value-added giggles.