### PR TITLE
Include route-addr support for RFC 822 and 1123

### DIFF
--- a/Tests/EmailValidator/Validation/RFCValidationTest.php
+++ b/Tests/EmailValidator/Validation/RFCValidationTest.php
@@ -71,6 +71,8 @@ class RFCValidationTest extends TestCase
     public function getValidEmails()
     {
         return array(
+            ['"Fabien Potencier" <fabien@symfony.com>'],
+            ['<fabien@symfony.com>'],
             ['â@iana.org'],
             ['fabien@symfony.com'],
             ['example@example.co.uk'],


### PR DESCRIPTION
Test valid addresses that use:
 - the mailbox format from RFC 822: phrase route-addr
 - the mailbox format from RFC 1123 (phrase optional): [phrase] route-addr

Hopefully the automated tests will show whether we're correctly supporting the RFC addresses in the mailbox route-addr format.