### PR TITLE
Advertise return annotations from doctrine/lexer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+dist: trusty
+
 language: php
 
 php:

--- a/EmailValidator/EmailLexer.php
+++ b/EmailValidator/EmailLexer.php
@@ -88,6 +88,9 @@ class EmailLexer extends AbstractLexer
         $this->previous = $this->token = self::$nullToken;
     }
 
+    /**
+     * @return void
+     */
     public function reset()
     {
         $this->hasInvalidTokens = false;
@@ -228,6 +231,9 @@ class EmailLexer extends AbstractLexer
         return false;
     }
 
+    /**
+     * @return string
+     */
     protected function getModifiers()
     {
         return 'iu';

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "extra": {
     "branch-alias": {
-      "dev-master": "2.0.x-dev"
+      "dev-master": "2.1.x-dev"
     }
   },
   "repositories": [


### PR DESCRIPTION
In order to help the ecosystem move forward with return types, the next version of Symfony will trigger deprecation notices when a child class doesn't declare the return type of one of its overriding methods.

This happens only for methods overriding third party packages.

The goal is that child classes move to add return types first so that vendors can then seamlessly add them too in their next major version bump.

The related PR is https://github.com/symfony/symfony/pull/30323
And this package is the last that triggers a notice with the new system:
https://travis-ci.org/symfony/symfony/jobs/570902186

Adding these annotations allows opting-out from the notices, meaning "I cannot add the return-type now because that'd be a BC break, but I'm aware that's something I need to fix when bumping to the next major of my package".

A quick merge would be greatly appreciated as that would unlock progress on our side :)