### PR TITLE
Composer tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 report/
 vendor/
 .idea
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Egulias\\Tests\\": "test"
+      "Egulias\\Tests\\": "Tests"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,6 @@
       "dev-master": "2.1.x-dev"
     }
   },
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/dominicsayers/isemail"
-    }
-  ],
   "require": {
     "php": ">=5.5",
     "doctrine/lexer": "^1.0.1"


### PR DESCRIPTION
as per request in #190, splitting the PR into topic-specific chunks.

* .gitignore edited to prevent accidental inclusion of composer.lock in a commit
* psr-4 autoloader config adjusted to reflect directory structure
* repositories entry removed as package is listed in packagist at the specified repo location, and inclusion can cause install issues under windows / git bash.