### PR TITLE
Fix "Trying to access array offset on value of type null"

### DIFF
--- a/EmailValidator/Parser/Parser.php
+++ b/EmailValidator/Parser/Parser.php
@@ -144,7 +144,7 @@ abstract class Parser
     {
         $previous = $this->lexer->getPrevious();
 
-        if ($previous['type'] === EmailLexer::S_BACKSLASH
+        if ($previous && $previous['type'] === EmailLexer::S_BACKSLASH
             &&
             $this->lexer->token['type'] !== EmailLexer::GENERIC
         ) {


### PR DESCRIPTION
Added a check that `$previous` is not null (i.e. previous token exists)