### PR TITLE
loading in symfony polyfill, partially resolves #177

### DIFF
--- a/EmailValidator/Validation/DNSCheckValidation.php
+++ b/EmailValidator/Validation/DNSCheckValidation.php
@@ -21,7 +21,7 @@ class DNSCheckValidation implements EmailValidation
     
     public function __construct()
     {
-        if (!extension_loaded('intl')) {
+        if (!function_exists('idn_to_ascii')) {
             throw new \LogicException(sprintf('The %s class requires the Intl extension.', __CLASS__));
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
   ],
   "require": {
     "php": ">=5.5",
-    "doctrine/lexer": "^1.0.1"
+    "doctrine/lexer": "^1.0.1",
+    "symfony/polyfill-intl-idn": "^1.10"
   },
   "require-dev": {
     "satooshi/php-coveralls": "^1.0.1",

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "symfony/polyfill-intl-idn": "^1.10"
   },
   "require-dev": {
+    "ext-intl": "*",
     "satooshi/php-coveralls": "^1.0.1",
     "phpunit/phpunit": "^4.8.36|^7.5.15",
     "dominicsayers/isemail": "^3.0.7"


### PR DESCRIPTION
* loads a polyfill instead of relying directly on extension
* requires intl extension for local dev.

regarding the change from `extension_loaded` to `function_exists`, [see conversation](https://github.com/egulias/EmailValidator/pull/190/commits/cb793ad34b3738b016b5726d5a765fd1b75138aa) from #190 