### PR TITLE
Fix local part length check

### DIFF
--- a/EmailValidator/Parser/LocalPart.php
+++ b/EmailValidator/Parser/LocalPart.php
@@ -19,6 +19,7 @@ class LocalPart extends Parser
         $parseDQuote = true;
         $closingQuote = false;
         $openedParenthesis = 0;
+        $totalLength = 0;
 
         while ($this->lexer->token['type'] !== EmailLexer::S_AT && null !== $this->lexer->token['type']) {
             if ($this->lexer->token['type'] === EmailLexer::S_DOT && null === $this->lexer->getPrevious()['type']) {
@@ -34,12 +35,13 @@ class LocalPart extends Parser
                 $this->parseComments();
                 $openedParenthesis += $this->getOpenedParenthesis();
             }
+
             if ($this->lexer->token['type'] === EmailLexer::S_CLOSEPARENTHESIS) {
                 if ($openedParenthesis === 0) {
                     throw new UnopenedComment();
-                } else {
-                    $openedParenthesis--;
                 }
+
+                $openedParenthesis--;
             }
 
             $this->checkConsecutiveDots();
@@ -57,11 +59,11 @@ class LocalPart extends Parser
                 $this->parseFWS();
             }
 
+            $totalLength += strlen($this->lexer->token['value']);
             $this->lexer->moveNext();
         }
 
-        $prev = $this->lexer->getPrevious();
-        if (strlen($prev['value']) > LocalTooLong::LOCAL_PART_LENGTH) {
+        if ($totalLength > LocalTooLong::LOCAL_PART_LENGTH) {
             $this->warnings[LocalTooLong::CODE] = new LocalTooLong();
         }
     }

--- a/Tests/EmailValidator/Validation/RFCValidationTest.php
+++ b/Tests/EmailValidator/Validation/RFCValidationTest.php
@@ -266,6 +266,10 @@ class RFCValidationTest extends TestCase
                 'too_long_localpart_too_long_localpart_too_long_localpart_too_long_localpart@invalid.example.com'
             ],
             [
+                [LocalTooLong::CODE],
+                'too_long_localpart_too_long_localpart_123_too_long_localpart_too_long_localpart@example.com'
+            ],
+            [
                 [LabelTooLong::CODE,],
                 'example@toolonglocalparttoolonglocalparttoolonglocalparttoolonglocalpart.co.uk'
             ],


### PR DESCRIPTION
The lexer would split the local part by known regexes rendering the total length check invalid, as it checked only the last token length instead of the whole local part.