### PR TITLE
Fix paths for tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,14 +12,14 @@
 >
 <testsuites>
   <testsuite name="EmailValidator Test Suite">
-    <directory>./Tests/EmailValidator</directory>
+    <directory>./tests/EmailValidator</directory>
     <exclude>./vendor/</exclude>
   </testsuite>
 </testsuites>
 
 <filter>
   <whitelist>
-    <directory>./EmailValidator/</directory>
+    <directory>./src/</directory>
   </whitelist>
 </filter>
 </phpunit>


### PR DESCRIPTION
Without:
```
$ phpunit7   --verbose
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.19
Configuration: /dev/shm/BUILD/EmailValidator-cfa3d44471c7f5bfb684ac2b0da7114283d78441/phpunit.xml.dist



Time: 8 ms, Memory: 4.00 MB

No tests executed!

```

Or see travis output ;)