### PR TITLE
Reimplement DNSCheckValidation

### DIFF
--- a/src/Exception/DomainAcceptsNoMail.php
+++ b/src/Exception/DomainAcceptsNoMail.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Egulias\EmailValidator\Exception;
+
+class DomainAcceptsNoMail extends InvalidEmail
+{
+    const CODE = 154;
+    const REASON = 'Domain accepts no mail (Null MX, RFC7505)';
+}

--- a/src/Exception/LocalOrReservedDomain.php
+++ b/src/Exception/LocalOrReservedDomain.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Egulias\EmailValidator\Exception;
+
+class LocalOrReservedDomain extends InvalidEmail
+{
+    const CODE = 153;
+    const REASON = 'Local, mDNS or reserved domain (RFC2606, RFC6762)';
+}

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -98,7 +98,7 @@ class DNSCheckValidation implements EmailValidation
         $dnsRecords = dns_get_record($host, DNS_MX + DNS_A + DNS_AAAA);
 
         // No MX, A or AAAA records
-        if (empty($dnsRecords) || !is_array($dnsRecords)) {
+        if (empty($dnsRecords)) {
             $this->error = new NoDNSRecord();
             return false;
         }

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -4,6 +4,8 @@ namespace Egulias\EmailValidator\Validation;
 
 use Egulias\EmailValidator\EmailLexer;
 use Egulias\EmailValidator\Exception\InvalidEmail;
+use Egulias\EmailValidator\Exception\LocalOrReservedDomain;
+use Egulias\EmailValidator\Exception\DomainAcceptsNoMail;
 use Egulias\EmailValidator\Warning\NoDNSMXRecord;
 use Egulias\EmailValidator\Exception\NoDNSRecord;
 
@@ -36,6 +38,36 @@ class DNSCheckValidation implements EmailValidation
             $host = substr($email, $lastAtPos + 1);
         }
 
+        // Get the domain parts
+        $hostParts = explode('.', $host);
+
+        // Reserved Top Level DNS Names (https://tools.ietf.org/html/rfc2606#section-2),
+        // mDNS and private DNS Namespaces (https://tools.ietf.org/html/rfc6762#appendix-G)
+        $reservedTopLevelDnsNames = [
+            // Reserved Top Level DNS Names
+            'test',
+            'example',
+            'invalid',
+            'localhost',
+
+            // mDNS
+            'local',
+
+            // Private DNS Namespaces
+            'intranet',
+            'internal',
+            'private',
+            'corp',
+            'home',
+            'lan',
+        ];
+
+        // Exclude reserved top level DNS names
+        if (count($hostParts) <= 1 || in_array($hostParts[(count($hostParts) - 1)], $reservedTopLevelDnsNames)) {
+            $this->error = new LocalOrReservedDomain();
+            return false;
+        }
+
         return $this->checkDNS($host);
     }
 
@@ -57,21 +89,46 @@ class DNSCheckValidation implements EmailValidation
     protected function checkDNS($host)
     {
         $variant = INTL_IDNA_VARIANT_2003;
-        if ( defined('INTL_IDNA_VARIANT_UTS46') ) {
+        if (defined('INTL_IDNA_VARIANT_UTS46')) {
             $variant = INTL_IDNA_VARIANT_UTS46;
         }
         $host = rtrim(idn_to_ascii($host, IDNA_DEFAULT, $variant), '.') . '.';
 
-        $Aresult = true;
-        $MXresult = checkdnsrr($host, 'MX');
+        // Get all MX, A and AAAA DNS records
+        $dnsRecords = dns_get_record($host, DNS_MX + DNS_A + DNS_AAAA);
 
-        if (!$MXresult) {
-            $this->warnings[NoDNSMXRecord::CODE] = new NoDNSMXRecord();
-            $Aresult = checkdnsrr($host, 'A') || checkdnsrr($host, 'AAAA');
-            if (!$Aresult) {
-                $this->error = new NoDNSRecord();
+        // No MX, A or AAAA records
+        if (empty($dnsRecords) || !is_array($dnsRecords)) {
+            $this->error = new NoDNSRecord();
+            return false;
+        }
+
+        $aRecords  = [];
+        $mxRecords = [];
+
+        // Iterate over all returned DNS records
+        foreach ($dnsRecords as $dnsRecord) {
+            if ($dnsRecord['type'] == 'MX') {
+                // "Null MX" record indicates the domain accepts no mail (https://tools.ietf.org/html/rfc7505)
+                if (empty($dnsRecord['target']) || $dnsRecord['target'] == '.') {
+                    $this->error = new DomainAcceptsNoMail();
+                    return false;
+                }
+
+                $mxRecords[] = $dnsRecord;
+                continue;
+            }
+
+            if (in_array($dnsRecord['type'], ['A', 'AAAA'])) {
+                $aRecords[] = $dnsRecord;
             }
         }
-        return $MXresult || $Aresult;
+
+        // No MX record
+        if (empty($mxRecords)) {
+            $this->warnings[NoDNSMXRecord::CODE] = new NoDNSMXRecord();
+        }
+
+        return true;
     }
 }

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -69,7 +69,7 @@ class DNSCheckValidation implements EmailValidation
         ];
 
         $isLocalDomain = count($hostParts) <= 1;
-        $isReservedTopLevel = in_array($hostParts[(count($hostParts) - 1)], $reservedTopLevelDnsNames);
+        $isReservedTopLevel = in_array($hostParts[(count($hostParts) - 1)], $reservedTopLevelDnsNames, true);
 
         // Exclude reserved top level DNS names
         if ($isLocalDomain || $isReservedTopLevel) {
@@ -151,12 +151,12 @@ class DNSCheckValidation implements EmailValidation
      */
     private function validateMxRecord($dnsRecord)
     {
-        if ($dnsRecord['type'] != 'MX') {
+        if ($dnsRecord['type'] !== 'MX') {
             return true;
         }
 
         // "Null MX" record indicates the domain accepts no mail (https://tools.ietf.org/html/rfc7505)
-        if (empty($dnsRecord['target']) || $dnsRecord['target'] == '.') {
+        if (empty($dnsRecord['target']) || $dnsRecord['target'] === '.') {
             $this->error = new DomainAcceptsNoMail();
             return false;
         }

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -111,7 +111,7 @@ class DNSCheckValidation implements EmailValidation
     /**
      * Validate the DNS records for given host.
      *
-     * @param array $host A set of DNS records in the format returned by dns_get_record.
+     * @param string $host A set of DNS records in the format returned by dns_get_record.
      *
      * @return bool True on success.
      */

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -68,8 +68,11 @@ class DNSCheckValidation implements EmailValidation
             'lan',
         ];
 
+        $isLocalDomain = count($hostParts) <= 1;
+        $isReservedTopLevel = in_array($hostParts[(count($hostParts) - 1)], $reservedTopLevelDnsNames);
+
         // Exclude reserved top level DNS names
-        if (count($hostParts) <= 1 || in_array($hostParts[(count($hostParts) - 1)], $reservedTopLevelDnsNames)) {
+        if ($isLocalDomain || $isReservedTopLevel) {
             $this->error = new LocalOrReservedDomain();
             return false;
         }
@@ -143,6 +146,8 @@ class DNSCheckValidation implements EmailValidation
      * Validate an MX record
      *
      * @param $dnsRecord A DNS record.
+     *
+     * @return bool True if valid.
      */
     private function validateMxRecord($dnsRecord)
     {

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -109,9 +109,9 @@ class DNSCheckValidation implements EmailValidation
 
 
     /**
-     * Validate the DNS records
+     * Validate the DNS records for given host.
      *
-     * @param array $dnsRecords A set of DNS records in the format returned by dns_get_record.
+     * @param array $host A set of DNS records in the format returned by dns_get_record.
      *
      * @return bool True on success.
      */
@@ -145,7 +145,7 @@ class DNSCheckValidation implements EmailValidation
     /**
      * Validate an MX record
      *
-     * @param array $dnsRecord A DNS record.
+     * @param array $dnsRecord Given DNS record.
      *
      * @return bool True if valid.
      */

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -111,7 +111,7 @@ class DNSCheckValidation implements EmailValidation
     /**
      * Validate the DNS records
      *
-     * @param $dnsRecords A set of DNS records in the format returned by dns_get_record.
+     * @param array $dnsRecords A set of DNS records in the format returned by dns_get_record.
      *
      * @return bool True on success.
      */
@@ -145,7 +145,7 @@ class DNSCheckValidation implements EmailValidation
     /**
      * Validate an MX record
      *
-     * @param $dnsRecord A DNS record.
+     * @param array $dnsRecord A DNS record.
      *
      * @return bool True if valid.
      */

--- a/tests/EmailValidator/Validation/DNSCheckValidationTest.php
+++ b/tests/EmailValidator/Validation/DNSCheckValidationTest.php
@@ -16,16 +16,16 @@ class DNSCheckValidationTest extends TestCase
     {
         return [
             // dot-atom
-            ['Abc@example.com'],
-            ['ABC@EXAMPLE.COM'],
-            ['Abc.123@example.com'],
-            ['user+mailbox/department=shipping@example.com'],
-            ['!#$%&\'*+-/=?^_`.{|}~@example.com'],
+            ['Abc@github.com'],
+            ['ABC@GITHUB.COM'],
+            ['Abc.123@github.com'],
+            ['user+mailbox/department=shipping@github.com'],
+            ['!#$%&\'*+-/=?^_`.{|}~@github.com'],
 
             // quoted string
-            ['"Abc@def"@example.com'],
-            ['"Fred\ Bloggs"@example.com'],
-            ['"Joe.\\Blow"@example.com'],
+            ['"Abc@def"@github.com'],
+            ['"Fred\ Bloggs"@github.com'],
+            ['"Joe.\\Blow"@github.com'],
 
             // unicide
             ['ñandu.cl'],

--- a/tests/EmailValidator/Validation/DNSCheckValidationTest.php
+++ b/tests/EmailValidator/Validation/DNSCheckValidationTest.php
@@ -4,6 +4,8 @@ namespace Egulias\EmailValidator\Tests\EmailValidator\Validation;
 
 use Egulias\EmailValidator\EmailLexer;
 use Egulias\EmailValidator\Exception\NoDNSRecord;
+use Egulias\EmailValidator\Exception\LocalOrReservedDomain;
+use Egulias\EmailValidator\Exception\DomainAcceptsNoMail;
 use Egulias\EmailValidator\Validation\DNSCheckValidation;
 use Egulias\EmailValidator\Warning\NoDNSMXRecord;
 use PHPUnit\Framework\TestCase;
@@ -30,30 +32,74 @@ class DNSCheckValidationTest extends TestCase
         ];
     }
 
+    public function localOrReservedEmailsProvider()
+    {
+        return [
+            // Reserved Top Level DNS Names
+            ['test'],
+            ['example'],
+            ['invalid'],
+            ['localhost'],
+
+            // mDNS
+            ['local'],
+
+            // Private DNS Namespaces
+            ['intranet'],
+            ['internal'],
+            ['private'],
+            ['corp'],
+            ['home'],
+            ['lan'],
+        ];
+    }
+
     /**
      * @dataProvider validEmailsProvider
      */
-    public function testValidDNS($validEmail)
+    public function testValidDns($validEmail)
     {
         $validation = new DNSCheckValidation();
         $this->assertTrue($validation->isValid($validEmail, new EmailLexer()));
     }
 
-    public function testInvalidDNS()
+    public function testInvalidDns()
     {
         $validation = new DNSCheckValidation();
         $this->assertFalse($validation->isValid("example@invalid.example.com", new EmailLexer()));
     }
 
-    public function testDNSWarnings()
+    /**
+     * @dataProvider localOrReservedEmailsProvider
+     */
+    public function testLocalOrReservedDomainError($localOrReservedEmails)
+    {
+        $validation = new DNSCheckValidation();
+        $expectedError = new LocalOrReservedDomain();
+        $validation->isValid($localOrReservedEmails, new EmailLexer());
+        $this->assertEquals($expectedError, $validation->getError());
+    }
+
+    public function testDomainAcceptsNoMailError()
+    {
+        $validation = new DNSCheckValidation();
+        $expectedError = new DomainAcceptsNoMail();
+        $isValidResult = $validation->isValid("example@example.com", new EmailLexer());
+        $this->assertEquals($expectedError, $validation->getError());
+        $this->assertFalse($isValidResult);
+    }
+
+    /*
+    public function testDnsWarnings()
     {
         $validation = new DNSCheckValidation();
         $expectedWarnings = [NoDNSMXRecord::CODE => new NoDNSMXRecord()];
         $validation->isValid("example@invalid.example.com", new EmailLexer());
         $this->assertEquals($expectedWarnings, $validation->getWarnings());
     }
+    */
 
-    public function testNoDNSError()
+    public function testNoDnsError()
     {
         $validation = new DNSCheckValidation();
         $expectedError = new NoDNSRecord();

--- a/tests/EmailValidator/Validation/DNSCheckValidationTest.php
+++ b/tests/EmailValidator/Validation/DNSCheckValidationTest.php
@@ -16,16 +16,16 @@ class DNSCheckValidationTest extends TestCase
     {
         return [
             // dot-atom
-            ['Abc@github.com'],
-            ['ABC@GITHUB.COM'],
-            ['Abc.123@github.com'],
-            ['user+mailbox/department=shipping@github.com'],
-            ['!#$%&\'*+-/=?^_`.{|}~@github.com'],
+            ['Abc@ietf.org'],
+            ['ABC@ietf.org'],
+            ['Abc.123@ietf.org'],
+            ['user+mailbox/department=shipping@ietf.org'],
+            ['!#$%&\'*+-/=?^_`.{|}~@ietf.org'],
 
             // quoted string
-            ['"Abc@def"@github.com'],
-            ['"Fred\ Bloggs"@github.com'],
-            ['"Joe.\\Blow"@github.com'],
+            ['"Abc@def"@ietf.org'],
+            ['"Fred\ Bloggs"@ietf.org'],
+            ['"Joe.\\Blow"@ietf.org'],
 
             // unicide
             ['ñandu.cl'],
@@ -57,13 +57,13 @@ class DNSCheckValidationTest extends TestCase
     /**
      * @dataProvider validEmailsProvider
      */
-    public function testValidDns($validEmail)
+    public function testValidDNS($validEmail)
     {
         $validation = new DNSCheckValidation();
         $this->assertTrue($validation->isValid($validEmail, new EmailLexer()));
     }
 
-    public function testInvalidDns()
+    public function testInvalidDNS()
     {
         $validation = new DNSCheckValidation();
         $this->assertFalse($validation->isValid("example@invalid.example.com", new EmailLexer()));
@@ -84,13 +84,13 @@ class DNSCheckValidationTest extends TestCase
     {
         $validation = new DNSCheckValidation();
         $expectedError = new DomainAcceptsNoMail();
-        $isValidResult = $validation->isValid("example@example.com", new EmailLexer());
+        $isValidResult = $validation->isValid("nullmx@example.com", new EmailLexer());
         $this->assertEquals($expectedError, $validation->getError());
         $this->assertFalse($isValidResult);
     }
 
     /*
-    public function testDnsWarnings()
+    public function testDNSWarnings()
     {
         $validation = new DNSCheckValidation();
         $expectedWarnings = [NoDNSMXRecord::CODE => new NoDNSMXRecord()];
@@ -99,7 +99,7 @@ class DNSCheckValidationTest extends TestCase
     }
     */
 
-    public function testNoDnsError()
+    public function testNoDNSError()
     {
         $validation = new DNSCheckValidation();
         $expectedError = new NoDNSRecord();


### PR DESCRIPTION
Utilise get_dns_record and extend support for the detection of Null MX records (RFC7505) and reserved, mDNS and private namespaces (RFC2606 & RFC6762). References #249.

I have had to remove the testDnsWarnings test as I'm not sure of any specific domains which have one or more A/AAAA records, but no MX records, which are not "Null MX" records.