### PR TITLE
fixed valid email with space

### DIFF
--- a/src/Parser/LocalPart.php
+++ b/src/Parser/LocalPart.php
@@ -135,7 +135,8 @@ class LocalPart extends Parser
             EmailLexer::S_LOWERTHAN,
             EmailLexer::S_COLON,
             EmailLexer::S_SEMICOLON,
-            EmailLexer::INVALID
+            EmailLexer::INVALID,
+            EmailLexer::S_SP
         );
 
         if (in_array($token['type'], $forbidden) && !$closingQuote) {


### PR DESCRIPTION
Before:
use Egulias\EmailValidator\EmailValidator;
use Egulias\EmailValidator\Validation\RFCValidation;

$validator = new EmailValidator();
$validator->isValid("example @example.com", new RFCValidation()); // true


After:

$validator = new EmailValidator();
$validator->isValid("example @example.com", new RFCValidation()); // false
