### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-
 matrix:
   include:
     - php: 5.5.9
@@ -25,6 +24,29 @@ matrix:
       env:
         - psalm=yes
     - php: 7.4
+      env:
+        - psalm=yes
+      dist: bionic
+#ppc64le support code
+    - php: 5.6
+      arch: ppc64le
+      env:
+      dist: xenial
+    - php: 7.0
+      arch: ppc64le
+      dist: xenial
+    - php: 7.1
+      arch: ppc64le
+      env:
+        - psalm=yes
+      dist: bionic
+    - php: 7.2
+      arch: ppc64le
+      env:
+        - psalm=yes
+      dist: bionic
+    - php: 7.4
+      arch: ppc64le
       env:
         - psalm=yes
       dist: bionic


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/EmailValidator