### PR TITLE
Bypass a PHP warning generated by @dns_get_record

### DIFF
--- a/src/Exception/UnableToGetDNSRecord.php
+++ b/src/Exception/UnableToGetDNSRecord.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Egulias\EmailValidator\Exception;
+
+class UnableToGetDNSRecord extends NoDNSRecord
+{
+    const CODE = 3;
+    const REASON = 'Unable to get DNS records for the host';
+}

--- a/tests/EmailValidator/Validation/DNSCheckValidationTest.php
+++ b/tests/EmailValidator/Validation/DNSCheckValidationTest.php
@@ -6,8 +6,8 @@ use Egulias\EmailValidator\EmailLexer;
 use Egulias\EmailValidator\Exception\NoDNSRecord;
 use Egulias\EmailValidator\Exception\LocalOrReservedDomain;
 use Egulias\EmailValidator\Exception\DomainAcceptsNoMail;
+use Egulias\EmailValidator\Exception\UnableToGetDNSRecord;
 use Egulias\EmailValidator\Validation\DNSCheckValidation;
-use Egulias\EmailValidator\Warning\NoDNSMXRecord;
 use PHPUnit\Framework\TestCase;
 
 class DNSCheckValidationTest extends TestCase
@@ -104,6 +104,16 @@ class DNSCheckValidationTest extends TestCase
         $validation = new DNSCheckValidation();
         $expectedError = new NoDNSRecord();
         $validation->isValid("example@invalid.example.com", new EmailLexer());
+        $this->assertEquals($expectedError, $validation->getError());
+    }
+
+    public function testUnableToGetDNSRecord()
+    {
+        error_reporting(\E_ALL);
+
+        $validation = new DNSCheckValidation();
+        $expectedError = new UnableToGetDNSRecord();
+        $validation->isValid("example@invalid-domain.com", new EmailLexer());
         $this->assertEquals($expectedError, $validation->getError());
     }
 }


### PR DESCRIPTION
Closes #256 

The idea is to create a custom error handler for `dns_get_record()`, call `dns_get_record` and then restore the original error handler.

This way we can catch PHP warnings (e.g. `Warning: dns_get_record(): DNS Query failed`) and errors: `dns_get_record(): A temporary server error occurred.` [ErrorException].


a new `UnableToGetDNSRecord` extends `NoDNSRecord` for backward compatibility reasons. Note sure about `CODE` const at the exception, I haven't found any rules for it.

## Why @ should be avoided

See https://derickrethans.nl/five-reasons-why-the-shutop-operator-should-be-avoided.html

In short:
 - can produce annoying side effects
 - it's slow