### PR TITLE
Use a safe way to execute dns_get_record (v3)

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,7 +7,7 @@ build:
     tests:
         override:
             -
-                command: 'vendor/bin/phpunit --coverage-clover=clover.xml'
+                command: 'vendor/bin/phpunit --coverage-clover=clover.xml --exclude-group slow'
                 coverage:
                     file: 'clover.xml'
                     format: 'clover'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - mkdir -p build/logs
 
 script:
-  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml --exclude-group slow
   - if [ "$psalm" = "yes" ]; then vendor/bin/psalm; fi
 
 after_script:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         executionOrder="defects"
          processIsolation="false"
          stopOnFailure="false"
-         bootstrap="vendor/autoload.php"
 >
 <testsuites>
   <testsuite name="EmailValidator Test Suite">

--- a/src/EmailLexer.php
+++ b/src/EmailLexer.php
@@ -125,6 +125,7 @@ class EmailLexer extends AbstractLexer
      * @var array
      *
      * @psalm-var array{value:string, type:null|int, position:int}
+     * @psalm-suppress NonInvariantDocblockPropertyType
      */
     public $token;
 

--- a/src/Result/Reason/UnableToGetDNSRecord.php
+++ b/src/Result/Reason/UnableToGetDNSRecord.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Egulias\EmailValidator\Result\Reason;
+
+/**
+ * Used on SERVFAIL, TIMEOUT or other runtime and network errors
+ */
+class UnableToGetDNSRecord extends NoDNSRecord
+{
+    public function code() : int
+    {
+        return 3;
+    }
+
+    public function description() : string
+    {
+        return 'Unable to get DNS records for the host';
+    }
+}

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -121,6 +121,7 @@ class DNSCheckValidation implements EmailValidation
     private function validateDnsRecords($host) : bool
     {
         // A workaround to fix https://bugs.php.net/bug.php?id=73149
+        /** @psalm-suppress InvalidArgument */
         set_error_handler(
             static function (int $errorLevel, string $errorMessage): ?bool {
                 throw new \RuntimeException("Unable to get DNS record for the host: $errorMessage");

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -13,6 +13,11 @@ use Egulias\EmailValidator\Warning\NoDNSMXRecord;
 class DNSCheckValidation implements EmailValidation
 {
     /**
+     * @var int
+     */
+    protected const DNS_RECORD_TYPES_TO_CHECK = DNS_MX + DNS_A + DNS_AAAA;
+
+    /**
      * @var array
      */
     private $warnings = [];
@@ -124,7 +129,7 @@ class DNSCheckValidation implements EmailValidation
 
         try {
             // Get all MX, A and AAAA DNS records for host
-            $dnsRecords = dns_get_record($host, DNS_MX + DNS_A + DNS_AAAA);
+            $dnsRecords = dns_get_record($host, static::DNS_RECORD_TYPES_TO_CHECK);
         } catch (\RuntimeException $exception) {
             $this->error = new InvalidEmail(new UnableToGetDNSRecord(), '');
 
@@ -134,7 +139,7 @@ class DNSCheckValidation implements EmailValidation
         }
 
         // No MX, A or AAAA DNS records
-        if ($dnsRecords === []) {
+        if ($dnsRecords === [] || $dnsRecords === false) {
             $this->error = new InvalidEmail(new ReasonNoDNSRecord(), '');
             return false;
         }

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -5,9 +5,10 @@ namespace Egulias\EmailValidator\Validation;
 use Egulias\EmailValidator\EmailLexer;
 use Egulias\EmailValidator\Result\InvalidEmail;
 use Egulias\EmailValidator\Result\Reason\DomainAcceptsNoMail;
-use Egulias\EmailValidator\Warning\NoDNSMXRecord;
 use Egulias\EmailValidator\Result\Reason\LocalOrReservedDomain;
 use Egulias\EmailValidator\Result\Reason\NoDNSRecord as ReasonNoDNSRecord;
+use Egulias\EmailValidator\Result\Reason\UnableToGetDNSRecord;
+use Egulias\EmailValidator\Warning\NoDNSMXRecord;
 
 class DNSCheckValidation implements EmailValidation
 {
@@ -114,12 +115,26 @@ class DNSCheckValidation implements EmailValidation
      */
     private function validateDnsRecords($host) : bool
     {
-        // Get all MX, A and AAAA DNS records for host
-        $dnsRecords = @dns_get_record($host, DNS_MX + DNS_A + DNS_AAAA);
+        // A workaround to fix https://bugs.php.net/bug.php?id=73149
+        set_error_handler(
+            static function (int $errorLevel, string $errorMessage): ?bool {
+                throw new \RuntimeException("Unable to get DNS record for the host: $errorMessage");
+            }
+        );
 
+        try {
+            // Get all MX, A and AAAA DNS records for host
+            $dnsRecords = dns_get_record($host, DNS_MX + DNS_A + DNS_AAAA);
+        } catch (\RuntimeException $exception) {
+            $this->error = new InvalidEmail(new UnableToGetDNSRecord(), '');
+
+            return false;
+        } finally {
+            restore_error_handler();
+        }
 
         // No MX, A or AAAA DNS records
-        if (empty($dnsRecords)) {
+        if ($dnsRecords === []) {
             $this->error = new InvalidEmail(new ReasonNoDNSRecord(), '');
             return false;
         }

--- a/tests/EmailValidator/Validation/DNSCheckValidationTest.php
+++ b/tests/EmailValidator/Validation/DNSCheckValidationTest.php
@@ -93,7 +93,7 @@ class DNSCheckValidationTest extends TestCase
 
     public function testDNSWarnings()
     {
-        $this->markTestSkipped('Need to found a domain with AAAA redords and no MX that fails later in the validations');
+        $this->markTestSkipped('Need to found a domain with AAAA records and no MX that fails later in the validations');
         $validation = new DNSCheckValidation();
         $expectedWarnings = [NoDNSMXRecord::CODE => new NoDNSMXRecord()];
         $validation->isValid("example@invalid.example.com", new EmailLexer());
@@ -108,13 +108,21 @@ class DNSCheckValidationTest extends TestCase
         $this->assertEquals($expectedError, $validation->getError());
     }
 
+    /**
+     * @group slow
+     */
     public function testUnableToGetDNSRecord()
     {
         error_reporting(\E_ALL);
 
-        $validation = new DNSCheckValidation();
+        // UnableToGetDNSRecord raises on network errors (e.g. timeout) that we can‘t emulate in tests (for sure),
+        // but we can try to get timeout error by trying to fetch all DNS records
+        $validation = new class extends DNSCheckValidation {
+            protected const DNS_RECORD_TYPES_TO_CHECK = \DNS_ALL;
+        };
         $expectedError = new InvalidEmail(new UnableToGetDNSRecord(), '');
-        $validation->isValid("example@invalid-domain.com", new EmailLexer());
+
+        $validation->isValid('example@invalid.example.com', new EmailLexer());
         $this->assertEquals($expectedError, $validation->getError());
     }
 }

--- a/tests/EmailValidator/Validation/DNSCheckValidationTest.php
+++ b/tests/EmailValidator/Validation/DNSCheckValidationTest.php
@@ -2,14 +2,15 @@
 
 namespace Egulias\EmailValidator\Tests\EmailValidator\Validation;
 
-use PHPUnit\Framework\TestCase;
 use Egulias\EmailValidator\EmailLexer;
 use Egulias\EmailValidator\Result\InvalidEmail;
-use Egulias\EmailValidator\Warning\NoDNSMXRecord;
-use Egulias\EmailValidator\Validation\DNSCheckValidation;
 use Egulias\EmailValidator\Result\Reason\DomainAcceptsNoMail;
 use Egulias\EmailValidator\Result\Reason\LocalOrReservedDomain;
 use Egulias\EmailValidator\Result\Reason\NoDNSRecord;
+use Egulias\EmailValidator\Result\Reason\UnableToGetDNSRecord;
+use Egulias\EmailValidator\Validation\DNSCheckValidation;
+use Egulias\EmailValidator\Warning\NoDNSMXRecord;
+use PHPUnit\Framework\TestCase;
 
 class DNSCheckValidationTest extends TestCase
 {
@@ -104,6 +105,16 @@ class DNSCheckValidationTest extends TestCase
         $validation = new DNSCheckValidation();
         $expectedError = new InvalidEmail(new NoDNSRecord(), '');
         $validation->isValid("example@invalid.example.com", new EmailLexer());
+        $this->assertEquals($expectedError, $validation->getError());
+    }
+
+    public function testUnableToGetDNSRecord()
+    {
+        error_reporting(\E_ALL);
+
+        $validation = new DNSCheckValidation();
+        $expectedError = new InvalidEmail(new UnableToGetDNSRecord(), '');
+        $validation->isValid("example@invalid-domain.com", new EmailLexer());
         $this->assertEquals($expectedError, $validation->getError());
     }
 }


### PR DESCRIPTION
Closes #256 (v3 branch)

The idea is to create a custom error handler for `dns_get_record()`, call `dns_get_record` and then restore the original error handler.

This way we can catch PHP warnings (e.g. `Warning: dns_get_record(): DNS Query failed`) and errors: `dns_get_record(): A temporary server error occurred.` [ErrorException].


a new `UnableToGetDNSRecord` extends `NoDNSRecord` for backward compatibility reasons. Note sure about `CODE` const at the exception, I haven't found any rules for it.

## Why @ should be avoided

See https://derickrethans.nl/five-reasons-why-the-shutop-operator-should-be-avoided.html

In short:
 - can produce annoying side effects
 - it's slow

## Why a new test disabled by default
`dns_get_record` returns false, generates E_WARNING in edge cases, that we can't control or easily mock from PHP code (e.g. timeouts). when use `dns_get_record($host, \DNS_ALL)`, it takes 60secs on my OS (macOS), 30secs on Docker container (ubuntu 18.04-based). For this reason I've decided to exclude this test by default on CI.
