### PR TITLE
Use a safe way to execute dns_get_record (v2) 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_script:
   - mkdir -p build/logs
 
 script:
-  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  - composer test:ci -- --coverage-clover build/logs/clover.xml
   - if [ "$psalm" = "yes" ]; then vendor/bin/psalm; fi
 
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,9 @@
     "psr-4": {
       "Egulias\\EmailValidator\\Tests\\": "tests"
     }
+  },
+  "scripts": {
+    "test": "phpunit",
+    "test:ci": "phpunit --exclude-group=slow"
   }
 }

--- a/src/Exception/UnableToGetDNSRecord.php
+++ b/src/Exception/UnableToGetDNSRecord.php
@@ -2,7 +2,7 @@
 
 namespace Egulias\EmailValidator\Exception;
 
-final class UnableToGetDNSRecord extends InvalidEmail
+final class UnableToGetDNSRecord extends NoDNSRecord
 {
     const CODE = 3;
     const REASON = 'Unable to get DNS records for the host';

--- a/src/Exception/UnableToGetDNSRecord.php
+++ b/src/Exception/UnableToGetDNSRecord.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Egulias\EmailValidator\Exception;
+
+final class UnableToGetDNSRecord extends InvalidEmail
+{
+    const CODE = 3;
+    const REASON = 'Unable to get DNS records for the host';
+}

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -123,8 +123,8 @@ class DNSCheckValidation implements EmailValidation
     private function validateDnsRecords($host)
     {
         // A workaround to fix https://bugs.php.net/bug.php?id=73149
-        /** @psalm-suppress InvalidArgument */
         set_error_handler(
+            /** @return never-return */
             static function ($errorLevel, $errorMessage) {
                 throw new \RuntimeException("Unable to get DNS record for the host: $errorMessage");
             }

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -124,7 +124,10 @@ class DNSCheckValidation implements EmailValidation
     {
         // A workaround to fix https://bugs.php.net/bug.php?id=73149
         set_error_handler(
-            /** @return never-return */
+            /**
+             * @psalm-suppress MissingClosureParamType
+             * @return never-return
+             */
             static function ($errorLevel, $errorMessage) {
                 throw new \RuntimeException("Unable to get DNS record for the host: $errorMessage");
             }


### PR DESCRIPTION
Backport of the `Use a safe way to execute dns_get_record (v3)` #286
___________

The idea is to create a custom error handler for dns_get_record(), call dns_get_record and then restore the original error handler.
This way we can catch PHP warnings (e.g. "Warning: dns_get_record(): DNS Query failed" or "dns_get_record(): A temporary server error occurred." [ErrorException])

## Tests

About failed tests: I think it’s not easily possible to test this case. Probably we can even remove a test I've added.

Also, I can't change Scrutinizer, it still tries to execute all tests