### PR TITLE
[3.x] Add null return type to getError DocBlock

### DIFF
--- a/src/Validation/EmailValidation.php
+++ b/src/Validation/EmailValidation.php
@@ -21,7 +21,7 @@ interface EmailValidation
     /**
      * Returns the validation error.
      *
-     * @return InvalidEmail
+     * @return InvalidEmail|null
      */
     public function getError() : ?InvalidEmail;
 


### PR DESCRIPTION
The return type here allows for `null` to be returned but this wasn't reflected in the DocBlock.