### PR TITLE
Honor RFC 5231 Domain Length

### DIFF
--- a/src/Parser/DomainPart.php
+++ b/src/Parser/DomainPart.php
@@ -280,9 +280,9 @@ class DomainPart extends PartParser
     {
         if ($this->lexer->token['type'] === EmailLexer::S_DOT || $isEndOfDomain) {
             if ($this->isLabelTooLong($this->label)) {
-                $this->label = '';
                 return new InvalidEmail(new LabelTooLong(), $this->lexer->token['value']);
             }
+            $this->label = '';
         }
         $this->label .= $this->lexer->token['value'];
         return new ValidEmail();

--- a/tests/EmailValidator/Validation/RFCValidationDomainPartTest.php
+++ b/tests/EmailValidator/Validation/RFCValidationDomainPartTest.php
@@ -76,6 +76,7 @@ class RFCValidationDomainPartTest extends TestCase
             ['validipv4@[127.0.0.0]'],
             ['validipv4@127.0.0.0'],
             ['withhyphen@domain-exam.com'],
+            ['valid_long_domain@71846jnrsoj91yfhc18rkbrf90ue3onl8y46js38kae8inz0t1.5a-xdycuau.na49.le.example.com']
         );
     }
 


### PR DESCRIPTION
According to RFC 5321 The Domain Part can be 255 octets.


Since this is testing just the domain part, we shouldn't be checking on the local label length of 64.

4.5.3.1.1.  Local-part
   The maximum total length of a user name or other local-part is 64 octets.

4.5.3.1.2.  Domain
   The maximum total length of a domain name or number is 255 octets.

https://tools.ietf.org/html/rfc5321


I moved some of the test data around to make it match correctly based on these rules.



Twitter: @johncongdon