### PR TITLE
MultipleErrors fails when retrieving the first reason, when this has a reason code <> 0

### DIFF
--- a/src/Result/MultipleErrors.php
+++ b/src/Result/MultipleErrors.php
@@ -21,7 +21,7 @@ class MultipleErrors extends InvalidEmail
 
     public function addReason(Reason $reason) : void
     {
-        $this->reasons[$reason->code()] = $reason;
+        $this->reasons[] = $reason;
     }
 
     /**


### PR DESCRIPTION
Having this adder method:

    public function addReason(Reason $reason) : void
    {
        $this->reasons[$reason->code()] = $reason;
    }

Will fail when

    public function reason() : Reason
    {
        return $this->reasons[0];
    }

If the $reason->code is different to 0.

That's why I propose in addReason having this line instead: $this->reasons[] = $reason;