### PR TITLE
Don't use utf8_en/decode() functions, they're deprecated on PHP 8.2

### DIFF
--- a/src/EmailLexer.php
+++ b/src/EmailLexer.php
@@ -237,7 +237,7 @@ class EmailLexer extends AbstractLexer
         $encoded = $value;
 
         if (mb_detect_encoding($value, 'auto', true) !== 'UTF-8') {
-            $encoded = utf8_encode($value);
+            $encoded = mb_convert_encoding($value, 'UTF-8', 'Windows-1252');
         }
 
         if ($this->isValid($encoded)) {

--- a/src/Parser/DomainPart.php
+++ b/src/Parser/DomainPart.php
@@ -292,7 +292,7 @@ class DomainPart extends PartParser
     private function isLabelTooLong(string $label) : bool
     {
         if (preg_match('/[^\x00-\x7F]/', $label)) {
-            idn_to_ascii(utf8_decode($label), IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46, $idnaInfo);
+            idn_to_ascii($label, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46, $idnaInfo);
             return (bool) ($idnaInfo['errors'] & IDNA_ERROR_LABEL_TOO_LONG);
         }
         return strlen($label) > self::LABEL_MAX_LENGTH;


### PR DESCRIPTION
For the call to idn_to_ascii(), [the doc](https://php.net/idn_to_ascii) tells that an UTF-8 string must be passed, so that calling utf8_decode() before doesn't make sense to me. I just removed the call.