### PR TITLE
Final public method for abstract class

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -32,7 +32,7 @@ abstract class Parser
         $this->lexer = $lexer;   
     }
 
-    public function parse(string $str) : Result
+    final public function parse(string $str) : Result
     {
         $this->lexer->setInput($str);
 
@@ -63,7 +63,7 @@ abstract class Parser
     /**
      * @return Warning\Warning[]
      */
-    public function getWarnings() : array
+    final public function getWarnings() : array
     {
         return $this->warnings;
     }

--- a/src/Parser/PartParser.php
+++ b/src/Parser/PartParser.php
@@ -30,7 +30,7 @@ abstract class PartParser
     /**
      * @return \Egulias\EmailValidator\Warning\Warning[]
      */
-    public function getWarnings()
+    final public function getWarnings()
     {
         return $this->warnings;
     }

--- a/src/Warning/Warning.php
+++ b/src/Warning/Warning.php
@@ -19,7 +19,7 @@ abstract class Warning
     /**
      * @return string
      */
-    public function message()
+    final public function message()
     {
         return $this->message;
     }
@@ -27,7 +27,7 @@ abstract class Warning
     /**
      * @return int
      */
-    public function code()
+    final public function code()
     {
         return self::CODE;
     }
@@ -35,7 +35,7 @@ abstract class Warning
     /**
      * @return int
      */
-    public function RFCNumber()
+    final public function RFCNumber()
     {
         return $this->rfcNumber;
     }


### PR DESCRIPTION
All public methods of abstract classes should be final. Enforce API encapsulation in an inheritance architecture. If you want to override a method, use the Template method pattern.