### PR TITLE
Work around deprecations from doctrine/lexer

### DIFF
--- a/src/EmailLexer.php
+++ b/src/EmailLexer.php
@@ -213,13 +213,11 @@ class EmailLexer extends AbstractLexer
     public function moveNext() : bool
     {
         if ($this->hasToRecord && $this->previous === self::$nullToken) {
-            $this->accumulator .= $this->token['value'];
+            $this->accumulator .= ((array) $this->token)['value'];
         }
 
-        $this->previous = $this->token instanceof Token
-            ? ['value' => $this->token->value, 'type' => $this->token->type, 'position' => $this->token->position]
-            : $this->token;
-        
+        $this->previous = (array) $this->token;
+
         if($this->lookahead === null) {
             $this->lookahead = self::$nullToken;
         }
@@ -227,7 +225,7 @@ class EmailLexer extends AbstractLexer
         $hasNext = parent::moveNext();
 
         if ($this->hasToRecord) {
-            $this->accumulator .= $this->token['value'];
+            $this->accumulator .= ((array) $this->token)['value'];
         }
 
         return $hasNext;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -29,7 +29,7 @@ abstract class Parser
 
     public function __construct(EmailLexer $lexer)
     {
-        $this->lexer = $lexer;   
+        $this->lexer = $lexer;
     }
 
     public function parse(string $str) : Result
@@ -51,7 +51,7 @@ abstract class Parser
             return $localPartResult;
         }
 
-        $domainPartResult = $this->parseRightFromAt(); 
+        $domainPartResult = $this->parseRightFromAt();
 
         if ($domainPartResult->isInvalid()) {
             return $domainPartResult;
@@ -73,6 +73,6 @@ abstract class Parser
         $this->lexer->moveNext();
         $this->lexer->moveNext();
 
-        return $this->lexer->token['type'] !== EmailLexer::S_AT;
+        return ((array) $this->lexer->token)['type'] !== EmailLexer::S_AT;
     }
 }

--- a/src/Parser/Comment.php
+++ b/src/Parser/Comment.php
@@ -31,15 +31,15 @@ class Comment extends PartParser
 
     public function parse() : Result
     {
-        if ($this->lexer->token['type'] === EmailLexer::S_OPENPARENTHESIS) {
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_OPENPARENTHESIS) {
             $this->openedParenthesis++;
             if($this->noClosingParenthesis()) {
-                return new InvalidEmail(new UnclosedComment(), $this->lexer->token['value']);
+                return new InvalidEmail(new UnclosedComment(), ((array) $this->lexer->token)['value']);
             }
         }
 
-        if ($this->lexer->token['type'] === EmailLexer::S_CLOSEPARENTHESIS) {
-            return new InvalidEmail(new UnOpenedComment(), $this->lexer->token['value']);
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_CLOSEPARENTHESIS) {
+            return new InvalidEmail(new UnOpenedComment(), ((array) $this->lexer->token)['value']);
         }
 
         $this->warnings[WarningComment::CODE] = new WarningComment();
@@ -58,10 +58,10 @@ class Comment extends PartParser
         }
 
         if($this->openedParenthesis >= 1) {
-            return new InvalidEmail(new UnclosedComment(), $this->lexer->token['value']);
+            return new InvalidEmail(new UnclosedComment(), ((array) $this->lexer->token)['value']);
         }
         if ($this->openedParenthesis < 0) {
-            return new InvalidEmail(new UnOpenedComment(), $this->lexer->token['value']);
+            return new InvalidEmail(new UnOpenedComment(), ((array) $this->lexer->token)['value']);
         }
 
         $finalValidations = $this->commentStrategy->endOfLoopValidations($this->lexer);
@@ -78,7 +78,7 @@ class Comment extends PartParser
     private function warnEscaping() : bool
     {
         //Backslash found
-        if ($this->lexer->token['type'] !== EmailLexer::S_BACKSLASH) {
+        if (((array) $this->lexer->token)['type'] !== EmailLexer::S_BACKSLASH) {
             return false;
         }
 
@@ -87,12 +87,12 @@ class Comment extends PartParser
         }
 
         $this->warnings[QuotedPart::CODE] =
-            new QuotedPart($this->lexer->getPrevious()['type'], $this->lexer->token['type']);
+            new QuotedPart($this->lexer->getPrevious()['type'], ((array) $this->lexer->token)['type']);
         return true;
 
     }
 
-    private function noClosingParenthesis() : bool 
+    private function noClosingParenthesis() : bool
     {
         try {
             $this->lexer->find(EmailLexer::S_CLOSEPARENTHESIS);

--- a/src/Parser/CommentStrategy/DomainComment.php
+++ b/src/Parser/CommentStrategy/DomainComment.php
@@ -23,7 +23,7 @@ class DomainComment implements CommentStrategy
     {
         //test for end of string
         if (!$lexer->isNextToken(EmailLexer::S_DOT)) {
-            return new InvalidEmail(new ExpectingATEXT('DOT not found near CLOSEPARENTHESIS'), $lexer->token['value']);
+            return new InvalidEmail(new ExpectingATEXT('DOT not found near CLOSEPARENTHESIS'), ((array) $lexer->token)['value']);
         }
         //add warning
         //Address is valid within the message but cannot be used unmodified for the envelope

--- a/src/Parser/CommentStrategy/LocalComment.php
+++ b/src/Parser/CommentStrategy/LocalComment.php
@@ -24,7 +24,7 @@ class LocalComment implements CommentStrategy
     public function endOfLoopValidations(EmailLexer $lexer) : Result
     {
         if (!$lexer->isNextToken(EmailLexer::S_AT)) {
-            return new InvalidEmail(new ExpectingATEXT('ATEX is not expected after closing comments'), $lexer->token['value']);
+            return new InvalidEmail(new ExpectingATEXT('ATEX is not expected after closing comments'), ((array) $lexer->token)['value']);
         }
         $this->warnings[CFWSNearAt::CODE] = new CFWSNearAt();
         return new ValidEmail();

--- a/src/Parser/DomainLiteral.php
+++ b/src/Parser/DomainLiteral.php
@@ -39,14 +39,14 @@ class DomainLiteral extends PartParser
         $addressLiteral = '';
 
         do {
-            if ($this->lexer->token['type'] === EmailLexer::C_NUL) {
-                return new InvalidEmail(new ExpectingDTEXT(), $this->lexer->token['value']);
+            if (((array) $this->lexer->token)['type'] === EmailLexer::C_NUL) {
+                return new InvalidEmail(new ExpectingDTEXT(), ((array) $this->lexer->token)['value']);
             }
 
             $this->addObsoleteWarnings();
 
             if ($this->lexer->isNextTokenAny(array(EmailLexer::S_OPENBRACKET, EmailLexer::S_OPENBRACKET))) {
-                return new InvalidEmail(new ExpectingDTEXT(), $this->lexer->token['value']);
+                return new InvalidEmail(new ExpectingDTEXT(), ((array) $this->lexer->token)['value']);
             }
 
             if ($this->lexer->isNextTokenAny(
@@ -57,21 +57,21 @@ class DomainLiteral extends PartParser
             }
 
             if ($this->lexer->isNextToken(EmailLexer::S_CR)) {
-                return new InvalidEmail(new CRNoLF(), $this->lexer->token['value']);
+                return new InvalidEmail(new CRNoLF(), ((array) $this->lexer->token)['value']);
             }
 
-            if ($this->lexer->token['type'] === EmailLexer::S_BACKSLASH) {
-                return new InvalidEmail(new UnusualElements($this->lexer->token['value']), $this->lexer->token['value']);
+            if (((array) $this->lexer->token)['type'] === EmailLexer::S_BACKSLASH) {
+                return new InvalidEmail(new UnusualElements(((array) $this->lexer->token)['value']), ((array) $this->lexer->token)['value']);
             }
-            if ($this->lexer->token['type'] === EmailLexer::S_IPV6TAG) {
+            if (((array) $this->lexer->token)['type'] === EmailLexer::S_IPV6TAG) {
                 $IPv6TAG = true;
             }
 
-            if ($this->lexer->token['type'] === EmailLexer::S_CLOSEBRACKET) {
+            if (((array) $this->lexer->token)['type'] === EmailLexer::S_CLOSEBRACKET) {
                 break;
             }
 
-            $addressLiteral .= $this->lexer->token['value'];
+            $addressLiteral .= ((array) $this->lexer->token)['value'];
 
         } while ($this->lexer->moveNext());
 
@@ -144,7 +144,7 @@ class DomainLiteral extends PartParser
             $this->warnings[IPV6Deprecated::CODE] = new IPV6Deprecated();
         }
     }
-    
+
     public function convertIPv4ToIPv6(string $addressLiteralIPv4) : string
     {
         $matchesIP  = [];
@@ -189,7 +189,7 @@ class DomainLiteral extends PartParser
 
     private function addObsoleteWarnings() : void
     {
-        if(in_array($this->lexer->token['type'], self::OBSOLETE_WARNINGS)) {
+        if(in_array(((array) $this->lexer->token)['type'], self::OBSOLETE_WARNINGS)) {
             $this->warnings[ObsoleteDTEXT::CODE] = new ObsoleteDTEXT();
         }
     }

--- a/src/Parser/DomainPart.php
+++ b/src/Parser/DomainPart.php
@@ -50,8 +50,8 @@ class DomainPart extends PartParser
             return $domainChecks;
         }
 
-        if ($this->lexer->token['type'] === EmailLexer::S_AT) {
-            return new InvalidEmail(new ConsecutiveAt(), $this->lexer->token['value']);
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_AT) {
+            return new InvalidEmail(new ConsecutiveAt(), ((array) $this->lexer->token)['value']);
         }
 
         $result = $this->doParseDomainPart();
@@ -69,7 +69,7 @@ class DomainPart extends PartParser
 
         $length = strlen($this->domainPart);
         if ($length > self::DOMAIN_MAX_LENGTH) {
-            return new InvalidEmail(new DomainTooLong(), $this->lexer->token['value']);
+            return new InvalidEmail(new DomainTooLong(), ((array) $this->lexer->token)['value']);
         }
 
         return new ValidEmail();
@@ -79,13 +79,13 @@ class DomainPart extends PartParser
     {
         $prev = $this->lexer->getPrevious();
         if ($prev['type'] === EmailLexer::S_DOT) {
-            return new InvalidEmail(new DotAtEnd(), $this->lexer->token['value']);
+            return new InvalidEmail(new DotAtEnd(), ((array) $this->lexer->token)['value']);
         }
         if ($prev['type'] === EmailLexer::S_HYPHEN) {
             return new InvalidEmail(new DomainHyphened('Hypen found at the end of the domain'), $prev['value']);
         }
 
-        if ($this->lexer->token['type'] === EmailLexer::S_SP) {
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_SP) {
             return new InvalidEmail(new CRLFAtTheEnd(), $prev['value']);
         }
         return new ValidEmail();
@@ -98,13 +98,13 @@ class DomainPart extends PartParser
         if ($invalidTokens->isInvalid()) {
             return $invalidTokens;
         }
-        
+
         $missingDomain = $this->checkEmptyDomain();
         if ($missingDomain->isInvalid()) {
             return $missingDomain;
         }
 
-        if ($this->lexer->token['type'] === EmailLexer::S_OPENPARENTHESIS) {
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_OPENPARENTHESIS) {
             $this->warnings[DeprecatedComment::CODE] = new DeprecatedComment();
         }
         return new ValidEmail();
@@ -112,12 +112,12 @@ class DomainPart extends PartParser
 
     private function checkEmptyDomain() : Result
     {
-        $thereIsNoDomain = $this->lexer->token['type'] === EmailLexer::S_EMPTY ||
-            ($this->lexer->token['type'] === EmailLexer::S_SP &&
+        $thereIsNoDomain = ((array) $this->lexer->token)['type'] === EmailLexer::S_EMPTY ||
+            (((array) $this->lexer->token)['type'] === EmailLexer::S_SP &&
             !$this->lexer->isNextToken(EmailLexer::GENERIC));
 
         if ($thereIsNoDomain) {
-            return new InvalidEmail(new NoDomainPart(), $this->lexer->token['value']);
+            return new InvalidEmail(new NoDomainPart(), ((array) $this->lexer->token)['value']);
         }
 
         return new ValidEmail();
@@ -125,11 +125,11 @@ class DomainPart extends PartParser
 
     private function checkInvalidTokensAfterAT() : Result
     {
-        if ($this->lexer->token['type'] === EmailLexer::S_DOT) {
-            return new InvalidEmail(new DotAtStart(), $this->lexer->token['value']);
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_DOT) {
+            return new InvalidEmail(new DotAtStart(), ((array) $this->lexer->token)['value']);
         }
-        if ($this->lexer->token['type'] === EmailLexer::S_HYPHEN) {
-            return new InvalidEmail(new DomainHyphened('After AT'), $this->lexer->token['value']);
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_HYPHEN) {
+            return new InvalidEmail(new DomainHyphened('After AT'), ((array) $this->lexer->token)['value']);
         }
         return new ValidEmail();
     }
@@ -156,8 +156,8 @@ class DomainPart extends PartParser
                 return $notAllowedChars;
             }
 
-            if ($this->lexer->token['type'] === EmailLexer::S_OPENPARENTHESIS || 
-                $this->lexer->token['type'] === EmailLexer::S_CLOSEPARENTHESIS ) {
+            if (((array) $this->lexer->token)['type'] === EmailLexer::S_OPENPARENTHESIS ||
+                ((array) $this->lexer->token)['type'] === EmailLexer::S_CLOSEPARENTHESIS ) {
                 $hasComments = true;
                 $commentsResult = $this->parseComments();
 
@@ -172,7 +172,7 @@ class DomainPart extends PartParser
                 return $dotsResult;
             }
 
-            if ($this->lexer->token['type'] === EmailLexer::S_OPENBRACKET) {
+            if (((array) $this->lexer->token)['type'] === EmailLexer::S_OPENBRACKET) {
                 $literalResult = $this->parseDomainLiteral();
 
                 $this->addTLDWarnings($tldMissing);
@@ -189,9 +189,9 @@ class DomainPart extends PartParser
                 return $FwsResult;
             }
 
-            $domain .= $this->lexer->token['value'];
+            $domain .= ((array) $this->lexer->token)['value'];
 
-            if ($this->lexer->token['type'] === EmailLexer::S_DOT && $this->lexer->isNextToken(EmailLexer::GENERIC)) {
+            if (((array) $this->lexer->token)['type'] === EmailLexer::S_DOT && $this->lexer->isNextToken(EmailLexer::GENERIC)) {
                 $tldMissing = false;
             }
 
@@ -201,7 +201,7 @@ class DomainPart extends PartParser
             }
             $this->lexer->moveNext();
 
-        } while (null !== $this->lexer->token['type']);
+        } while (null !== ((array) $this->lexer->token)['type']);
 
         $labelCheck = $this->checkLabelLength(true);
         if ($labelCheck->isInvalid()) {
@@ -219,8 +219,8 @@ class DomainPart extends PartParser
     private function checkNotAllowedChars($token) : Result
     {
         $notAllowed = [EmailLexer::S_BACKSLASH => true, EmailLexer::S_SLASH=> true];
-        if (isset($notAllowed[$token['type']])) {
-            return new InvalidEmail(new CharNotAllowed(), $token['value']);
+        if (isset($notAllowed[((array) $token)['type']])) {
+            return new InvalidEmail(new CharNotAllowed(), ((array) $token)['value']);
         }
         return new ValidEmail();
     }
@@ -233,7 +233,7 @@ class DomainPart extends PartParser
         try {
             $this->lexer->find(EmailLexer::S_CLOSEBRACKET);
         } catch (\RuntimeException $e) {
-            return new InvalidEmail(new ExpectingDomainLiteralClose(), $this->lexer->token['value']);
+            return new InvalidEmail(new ExpectingDomainLiteralClose(), ((array) $this->lexer->token)['value']);
         }
 
         $domainLiteralParser = new DomainLiteralParser($this->lexer);
@@ -244,17 +244,17 @@ class DomainPart extends PartParser
 
     protected function checkDomainPartExceptions(array $prev, bool $hasComments) : Result
     {
-        if ($this->lexer->token['type'] === EmailLexer::S_OPENBRACKET && $prev['type'] !== EmailLexer::S_AT) {
-            return new InvalidEmail(new ExpectingATEXT('OPENBRACKET not after AT'), $this->lexer->token['value']);
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_OPENBRACKET && $prev['type'] !== EmailLexer::S_AT) {
+            return new InvalidEmail(new ExpectingATEXT('OPENBRACKET not after AT'), ((array) $this->lexer->token)['value']);
         }
 
-        if ($this->lexer->token['type'] === EmailLexer::S_HYPHEN && $this->lexer->isNextToken(EmailLexer::S_DOT)) {
-            return new InvalidEmail(new DomainHyphened('Hypen found near DOT'), $this->lexer->token['value']);
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_HYPHEN && $this->lexer->isNextToken(EmailLexer::S_DOT)) {
+            return new InvalidEmail(new DomainHyphened('Hypen found near DOT'), ((array) $this->lexer->token)['value']);
         }
 
-        if ($this->lexer->token['type'] === EmailLexer::S_BACKSLASH
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_BACKSLASH
             && $this->lexer->isNextToken(EmailLexer::GENERIC)) {
-            return new InvalidEmail(new ExpectingATEXT('Escaping following "ATOM"'), $this->lexer->token['value']);
+            return new InvalidEmail(new ExpectingATEXT('Escaping following "ATOM"'), ((array) $this->lexer->token)['value']);
         }
 
         return $this->validateTokens($hasComments);
@@ -273,8 +273,8 @@ class DomainPart extends PartParser
             $validDomainTokens[EmailLexer::S_CLOSEPARENTHESIS] = true;
         }
 
-        if (!isset($validDomainTokens[$this->lexer->token['type']])) {
-            return new InvalidEmail(new ExpectingATEXT('Invalid token in domain: ' . $this->lexer->token['value']), $this->lexer->token['value']);
+        if (!isset($validDomainTokens[((array) $this->lexer->token)['type']])) {
+            return new InvalidEmail(new ExpectingATEXT('Invalid token in domain: ' . ((array) $this->lexer->token)['value']), ((array) $this->lexer->token)['value']);
         }
 
         return new ValidEmail();
@@ -282,13 +282,13 @@ class DomainPart extends PartParser
 
     private function checkLabelLength(bool $isEndOfDomain = false) : Result
     {
-        if ($this->lexer->token['type'] === EmailLexer::S_DOT || $isEndOfDomain) {
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_DOT || $isEndOfDomain) {
             if ($this->isLabelTooLong($this->label)) {
-                return new InvalidEmail(new LabelTooLong(), $this->lexer->token['value']);
+                return new InvalidEmail(new LabelTooLong(), ((array) $this->lexer->token)['value']);
             }
             $this->label = '';
         }
-        $this->label .= $this->lexer->token['value'];
+        $this->label .= ((array) $this->lexer->token)['value'];
         return new ValidEmail();
     }
 

--- a/src/Parser/DoubleQuote.php
+++ b/src/Parser/DoubleQuote.php
@@ -30,24 +30,24 @@ class DoubleQuote extends PartParser
             EmailLexer::S_CR => true,
             EmailLexer::S_LF => true
         ];
-        
+
         $setSpecialsWarning = true;
 
         $this->lexer->moveNext();
 
-        while ($this->lexer->token['type'] !== EmailLexer::S_DQUOTE && null !== $this->lexer->token['type']) {
-            if (isset($special[$this->lexer->token['type']]) && $setSpecialsWarning) {
+        while (((array) $this->lexer->token)['type'] !== EmailLexer::S_DQUOTE && null !== ((array) $this->lexer->token)['type']) {
+            if (isset($special[((array) $this->lexer->token)['type']]) && $setSpecialsWarning) {
                 $this->warnings[CFWSWithFWS::CODE] = new CFWSWithFWS();
                 $setSpecialsWarning = false;
             }
-            if ($this->lexer->token['type'] === EmailLexer::S_BACKSLASH && $this->lexer->isNextToken(EmailLexer::S_DQUOTE)) {
+            if (((array) $this->lexer->token)['type'] === EmailLexer::S_BACKSLASH && $this->lexer->isNextToken(EmailLexer::S_DQUOTE)) {
                 $this->lexer->moveNext();
             }
 
             $this->lexer->moveNext();
 
-            if (!$this->escaped() && isset($invalid[$this->lexer->token['type']])) {
-                return new InvalidEmail(new ExpectingATEXT("Expecting ATEXT between DQUOTE"), $this->lexer->token['value']);
+            if (!$this->escaped() && isset($invalid[((array) $this->lexer->token)['type']])) {
+                return new InvalidEmail(new ExpectingATEXT("Expecting ATEXT between DQUOTE"), ((array) $this->lexer->token)['value']);
             }
         }
 
@@ -59,7 +59,7 @@ class DoubleQuote extends PartParser
         }
 
         if (!$this->lexer->isNextToken(EmailLexer::S_AT) && $prev['type'] !== EmailLexer::S_BACKSLASH) {
-            return new InvalidEmail(new ExpectingATEXT("Expecting ATEXT between DQUOTE"), $this->lexer->token['value']);
+            return new InvalidEmail(new ExpectingATEXT("Expecting ATEXT between DQUOTE"), ((array) $this->lexer->token)['value']);
         }
 
         return new ValidEmail();
@@ -71,15 +71,15 @@ class DoubleQuote extends PartParser
 
         if ($this->lexer->isNextToken(EmailLexer::GENERIC) && $previous['type'] === EmailLexer::GENERIC) {
             $description = 'https://tools.ietf.org/html/rfc5322#section-3.2.4 - quoted string should be a unit';
-            return new InvalidEmail(new ExpectingATEXT($description), $this->lexer->token['value']);
+            return new InvalidEmail(new ExpectingATEXT($description), ((array) $this->lexer->token)['value']);
         }
 
         try {
             $this->lexer->find(EmailLexer::S_DQUOTE);
         } catch (\Exception $e) {
-            return new InvalidEmail(new UnclosedQuotedString(), $this->lexer->token['value']);
+            return new InvalidEmail(new UnclosedQuotedString(), ((array) $this->lexer->token)['value']);
         }
-        $this->warnings[QuotedString::CODE] = new QuotedString($previous['value'], $this->lexer->token['value']);
+        $this->warnings[QuotedString::CODE] = new QuotedString($previous['value'], ((array) $this->lexer->token)['value']);
 
         return new ValidEmail();
     }

--- a/src/Parser/FoldingWhiteSpace.php
+++ b/src/Parser/FoldingWhiteSpace.php
@@ -36,16 +36,16 @@ class  FoldingWhiteSpace extends PartParser
             return $resultCRLF;
         }
 
-        if ($this->lexer->token['type'] === EmailLexer::S_CR) {
-            return new InvalidEmail(new CRNoLF(), $this->lexer->token['value']);
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_CR) {
+            return new InvalidEmail(new CRNoLF(), ((array) $this->lexer->token)['value']);
         }
 
         if ($this->lexer->isNextToken(EmailLexer::GENERIC) && $previous['type']  !== EmailLexer::S_AT) {
-            return new InvalidEmail(new AtextAfterCFWS(), $this->lexer->token['value']);
+            return new InvalidEmail(new AtextAfterCFWS(), ((array) $this->lexer->token)['value']);
         }
 
-        if ($this->lexer->token['type'] === EmailLexer::S_LF || $this->lexer->token['type'] === EmailLexer::C_NUL) {
-            return new InvalidEmail(new ExpectingCTEXT(), $this->lexer->token['value']);
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_LF || ((array) $this->lexer->token)['type'] === EmailLexer::C_NUL) {
+            return new InvalidEmail(new ExpectingCTEXT(), ((array) $this->lexer->token)['value']);
         }
 
         if ($this->lexer->isNextToken(EmailLexer::S_AT) || $previous['type']  === EmailLexer::S_AT) {
@@ -59,28 +59,28 @@ class  FoldingWhiteSpace extends PartParser
 
     protected function checkCRLFInFWS() : Result
     {
-        if ($this->lexer->token['type'] !== EmailLexer::CRLF) {
+        if (((array) $this->lexer->token)['type'] !== EmailLexer::CRLF) {
             return new ValidEmail();
         }
 
         if (!$this->lexer->isNextTokenAny(array(EmailLexer::S_SP, EmailLexer::S_HTAB))) {
-            return new InvalidEmail(new CRLFX2(), $this->lexer->token['value']);
+            return new InvalidEmail(new CRLFX2(), ((array) $this->lexer->token)['value']);
         }
 
         //this has no coverage. Condition is repeated from above one
         if (!$this->lexer->isNextTokenAny(array(EmailLexer::S_SP, EmailLexer::S_HTAB))) {
-            return new InvalidEmail(new CRLFAtTheEnd(), $this->lexer->token['value']);
+            return new InvalidEmail(new CRLFAtTheEnd(), ((array) $this->lexer->token)['value']);
         }
 
         return new ValidEmail();
     }
-     
+
     protected function isFWS() : bool
     {
         if ($this->escaped()) {
             return false;
         }
 
-        return in_array($this->lexer->token['type'], self::FWS_TYPES);
+        return in_array(((array) $this->lexer->token)['type'], self::FWS_TYPES);
     }
 }

--- a/src/Parser/IDLeftPart.php
+++ b/src/Parser/IDLeftPart.php
@@ -10,6 +10,6 @@ class IDLeftPart extends LocalPart
 {
     protected function parseComments(): Result
     {
-       return new InvalidEmail(new CommentsInIDRight(), $this->lexer->token['value']);
+       return new InvalidEmail(new CommentsInIDRight(), ((array) $this->lexer->token)['value']);
     }
 }

--- a/src/Parser/IDRightPart.php
+++ b/src/Parser/IDRightPart.php
@@ -20,9 +20,9 @@ class IDRightPart extends DomainPart
             EmailLexer::S_GREATERTHAN => true,
             EmailLexer::S_LOWERTHAN => true,
         ];
-    
-        if (isset($invalidDomainTokens[$this->lexer->token['type']])) {
-            return new InvalidEmail(new ExpectingATEXT('Invalid token in domain: ' . $this->lexer->token['value']), $this->lexer->token['value']);
+
+        if (isset($invalidDomainTokens[((array) $this->lexer->token)['type']])) {
+            return new InvalidEmail(new ExpectingATEXT('Invalid token in domain: ' . ((array) $this->lexer->token)['value']), ((array) $this->lexer->token)['value']);
         }
         return new ValidEmail();
     }

--- a/src/Parser/LocalPart.php
+++ b/src/Parser/LocalPart.php
@@ -36,12 +36,12 @@ class LocalPart extends PartParser
     {
         $this->lexer->startRecording();
 
-        while ($this->lexer->token['type'] !== EmailLexer::S_AT && null !== $this->lexer->token['type']) {
+        while (((array) $this->lexer->token)['type'] !== EmailLexer::S_AT && null !== ((array) $this->lexer->token)['type']) {
             if ($this->hasDotAtStart()) {
-                return new InvalidEmail(new DotAtStart(), $this->lexer->token['value']);
+                return new InvalidEmail(new DotAtStart(), ((array) $this->lexer->token)['value']);
             }
 
-            if ($this->lexer->token['type'] === EmailLexer::S_DQUOTE) {
+            if (((array) $this->lexer->token)['type'] === EmailLexer::S_DQUOTE) {
                 $dquoteParsingResult = $this->parseDoubleQuote();
 
                 //Invalid double quote parsing
@@ -50,8 +50,8 @@ class LocalPart extends PartParser
                 }
             }
 
-            if ($this->lexer->token['type'] === EmailLexer::S_OPENPARENTHESIS || 
-                $this->lexer->token['type'] === EmailLexer::S_CLOSEPARENTHESIS ) {
+            if (((array) $this->lexer->token)['type'] === EmailLexer::S_OPENPARENTHESIS ||
+                ((array) $this->lexer->token)['type'] === EmailLexer::S_CLOSEPARENTHESIS ) {
                 $commentsResult = $this->parseComments();
 
                 //Invalid comment parsing
@@ -60,14 +60,14 @@ class LocalPart extends PartParser
                 }
             }
 
-            if ($this->lexer->token['type'] === EmailLexer::S_DOT && $this->lexer->isNextToken(EmailLexer::S_DOT)) {
-                return new InvalidEmail(new ConsecutiveDot(), $this->lexer->token['value']);
+            if (((array) $this->lexer->token)['type'] === EmailLexer::S_DOT && $this->lexer->isNextToken(EmailLexer::S_DOT)) {
+                return new InvalidEmail(new ConsecutiveDot(), ((array) $this->lexer->token)['value']);
             }
 
-            if ($this->lexer->token['type'] === EmailLexer::S_DOT &&
+            if (((array) $this->lexer->token)['type'] === EmailLexer::S_DOT &&
                 $this->lexer->isNextToken(EmailLexer::S_AT)
             ) {
-                return new InvalidEmail(new DotAtEnd(), $this->lexer->token['value']);
+                return new InvalidEmail(new DotAtEnd(), ((array) $this->lexer->token)['value']);
             }
 
             $resultEscaping = $this->validateEscaping();
@@ -99,8 +99,8 @@ class LocalPart extends PartParser
 
     protected function validateTokens(bool $hasComments) : Result
     {
-        if (isset(self::INVALID_TOKENS[$this->lexer->token['type']])) {
-            return new InvalidEmail(new ExpectingATEXT('Invalid token found'), $this->lexer->token['value']);
+        if (isset(self::INVALID_TOKENS[((array) $this->lexer->token)['type']])) {
+            return new InvalidEmail(new ExpectingATEXT('Invalid token found'), ((array) $this->lexer->token)['value']);
         }
         return new ValidEmail();
     }
@@ -110,7 +110,7 @@ class LocalPart extends PartParser
         return $this->localPart;
     }
 
-    private function parseLocalFWS() : Result 
+    private function parseLocalFWS() : Result
     {
         $foldingWS = new FoldingWhiteSpace($this->lexer);
         $resultFWS = $foldingWS->parse();
@@ -122,7 +122,7 @@ class LocalPart extends PartParser
 
     private function hasDotAtStart() : bool
     {
-            return $this->lexer->token['type'] === EmailLexer::S_DOT && null === $this->lexer->getPrevious()['type'];
+            return ((array) $this->lexer->token)['type'] === EmailLexer::S_DOT && null === $this->lexer->getPrevious()['type'];
     }
 
     private function parseDoubleQuote() : Result
@@ -148,12 +148,12 @@ class LocalPart extends PartParser
     private function validateEscaping() : Result
     {
         //Backslash found
-        if ($this->lexer->token['type'] !== EmailLexer::S_BACKSLASH) {
+        if (((array) $this->lexer->token)['type'] !== EmailLexer::S_BACKSLASH) {
             return new ValidEmail();
         }
 
         if ($this->lexer->isNextToken(EmailLexer::GENERIC)) {
-            return new InvalidEmail(new ExpectingATEXT('Found ATOM after escaping'), $this->lexer->token['value']);
+            return new InvalidEmail(new ExpectingATEXT('Found ATOM after escaping'), ((array) $this->lexer->token)['value']);
         }
 
         if (!$this->lexer->isNextTokenAny(array(EmailLexer::S_SP, EmailLexer::S_HTAB, EmailLexer::C_DEL))) {

--- a/src/Parser/PartParser.php
+++ b/src/Parser/PartParser.php
@@ -45,8 +45,8 @@ abstract class PartParser
 
     protected function checkConsecutiveDots() : Result
     {
-        if ($this->lexer->token['type'] === EmailLexer::S_DOT && $this->lexer->isNextToken(EmailLexer::S_DOT)) {
-            return new InvalidEmail(new ConsecutiveDot(), $this->lexer->token['value']);
+        if (((array) $this->lexer->token)['type'] === EmailLexer::S_DOT && $this->lexer->isNextToken(EmailLexer::S_DOT)) {
+            return new InvalidEmail(new ConsecutiveDot(), ((array) $this->lexer->token)['value']);
         }
 
         return new ValidEmail();
@@ -58,6 +58,6 @@ abstract class PartParser
 
         return $previous && $previous['type'] === EmailLexer::S_BACKSLASH
             &&
-            $this->lexer->token['type'] !== EmailLexer::GENERIC;
+            ((array) $this->lexer->token)['type'] !== EmailLexer::GENERIC;
     }
 }


### PR DESCRIPTION
Version 3 of egulias/email-validator is the latest that works on PHP 7.2, thus it's the version that we use to test Symfony 5.4 on PHP 7.2.

Since we enabled reporting of deprecations from Doctrine, we are flooded with notices triggered by this package, because it relies on the deprecated array-style to read tokens.

This PR fixes it.

A quick merge would be appreciated to remove so many failures on our CI :pray: 

And a release would help ppl on 7.2 to not have these deprecations also of course.
