### PR TITLE
Make private functions protected in DNSCheckValidation.php

### DIFF
--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -147,7 +147,7 @@ class DNSCheckValidation implements EmailValidation
      *
      * @return bool True on success.
      */
-    private function validateDnsRecords($host): bool
+    protected function validateDnsRecords($host): bool
     {
         $dnsRecordsResult = $this->dnsGetRecord->getRecords($host, static::DNS_RECORD_TYPES_TO_CHECK);
 
@@ -184,7 +184,7 @@ class DNSCheckValidation implements EmailValidation
      *
      * @return bool True if valid.
      */
-    private function validateMxRecord($dnsRecord): bool
+    protected function validateMxRecord($dnsRecord): bool
     {
         if (!isset($dnsRecord['type'])) {
             $this->error = new InvalidEmail(new ReasonNoDNSRecord(), '');


### PR DESCRIPTION
I have to add some lines in `validateDnsRecords` 

```php
        // It was added in checkDns()
        $hostWithoutFinalDot = substr($host, 0, -1);
        if (in_array($hostWithoutFinalDot, self::BAD_TYPO_DOMAINS)) {
            return false;
        }
```

And this will abort the domain checking for BAD_TYPO_DOMAINS that are typo domains.
Like : `hormail.fr` typo of `hotmail.fr`
Passes MX check and all other tests.
But is a typo and then invalid