### PR TITLE
Regularise a test.

### DIFF
--- a/tests/EmailValidator/Validation/DNSCheckValidationTest.php
+++ b/tests/EmailValidator/Validation/DNSCheckValidationTest.php
@@ -32,8 +32,9 @@ class DNSCheckValidationTest extends TestCase
             ['"Fred\ Bloggs"@ietf.org'],
             ['"Joe.\\Blow"@ietf.org'],
 
-            // unicide
-            ['ñandu.cl'],
+            // unicode
+            ['info@ñandu.cl'],
+            ['ñandu@ñandu.cl'],
         ];
     }
 


### PR DESCRIPTION
The validEmailsProvider contained n-1 valid email addresses and 1 domain; this replaces the domain with two valid email addresses in that domain, so that all entries match the name.