### PR TITLE
Fix issue that local part parser uses remaining code from lexer with multiple email addresses

### DIFF
--- a/src/Parser/LocalPart.php
+++ b/src/Parser/LocalPart.php
@@ -34,6 +34,7 @@ class LocalPart extends PartParser
 
     public function parse(): Result
     {
+        $this->lexer->clearRecorded();
         $this->lexer->startRecording();
 
         while (!$this->lexer->current->isA(EmailLexer::S_AT) && !$this->lexer->current->isA(EmailLexer::S_EMPTY)) {

--- a/tests/EmailValidator/EmailParserTest.php
+++ b/tests/EmailValidator/EmailParserTest.php
@@ -28,4 +28,18 @@ class EmailParserTest extends TestCase
         $this->assertEquals($local, $parser->getLocalPart());
         $this->assertEquals($domain, $parser->getDomainPart());
     }
+
+    public function testMultipleEmailAddresses()
+    {
+        $parser = new EmailParser(new EmailLexer());
+        $parser->parse('some-local-part@some-random-but-large-domain-part.example.com');
+
+        $this->assertSame('some-local-part', $parser->getLocalPart());
+        $this->assertSame('some-random-but-large-domain-part.example.com', $parser->getDomainPart());
+
+        $parser->parse('another-local-part@another.example.com');
+
+        $this->assertSame('another-local-part', $parser->getLocalPart());
+        $this->assertSame('another.example.com', $parser->getDomainPart());
+    }
 }


### PR DESCRIPTION
This issue resolves an issue when you use the EmailValidator for multiple email addresses without creating a new instance for every email address (Similar to [issue 150](https://github.com/egulias/EmailValidator/issues/150)).

Without this fix the added test will output

```
1) Egulias\EmailValidator\Tests\EmailValidator\EmailParserTest::testMultipleEmailAddresses Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'another-local-part'
+'some-random-but-large-domain-part.example.comanother-local-part'
```