### PR TITLE
Fix connection timeout issue when try combine MX + A records for specfic DNS when A record not exists

### DIFF
--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -181,6 +181,11 @@ class DNSCheckValidation implements EmailValidation
             return false;
         }
 
+        return $this->validateMxRecords($dnsRecords);
+    }
+
+    private function validateMxRecords($dnsRecords): bool
+    {
         // For each DNS record
         foreach ($dnsRecords as $dnsRecord) {
             if (!$this->validateMXRecord($dnsRecord)) {
@@ -191,6 +196,7 @@ class DNSCheckValidation implements EmailValidation
                 return false;
             }
         }
+
         return true;
     }
 

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -17,7 +17,7 @@ class DNSCheckValidation implements EmailValidation
     /**
      * Reserved Top Level DNS Names (https://tools.ietf.org/html/rfc2606#section-2),
      * mDNS and private DNS Namespaces (https://tools.ietf.org/html/rfc6762#appendix-G)
-     * 
+     *
      * @var string[]
      */
     public const RESERVED_DNS_TOP_LEVEL_NAMES = [
@@ -145,14 +145,20 @@ class DNSCheckValidation implements EmailValidation
      */
     private function validateDnsRecords($host): bool
     {
-        $dnsRecordsResult = $this->dnsGetRecord->getRecords($host, DNS_A + DNS_MX);
+        $dnsRecords = [];
 
-        if ($dnsRecordsResult->withError()) {
-            $this->error = new InvalidEmail(new UnableToGetDNSRecord(), '');
-            return false;
+        $mxRecordsResult = $this->dnsGetRecord->getRecords($host, DNS_MX);
+
+        if (! $mxRecordsResult->withError()) {
+            $dnsRecords = $mxRecordsResult->getRecords();
         }
 
-        $dnsRecords = $dnsRecordsResult->getRecords();
+        // Combined check for A+MX can fail with connection timed out, even in the presence of valid MX record
+        $aRecordsResult = $this->dnsGetRecord->getRecords($host, DNS_A);
+
+        if (! $aRecordsResult->withError()) {
+            $dnsRecords = array_merge($dnsRecords, $aRecordsResult->getRecords());
+        }
 
         // Combined check for A+MX+AAAA can fail with SERVFAIL, even in the presence of valid A/MX records
         $aaaaRecordsResult = $this->dnsGetRecord->getRecords($host, DNS_AAAA);
@@ -163,6 +169,14 @@ class DNSCheckValidation implements EmailValidation
 
         // No MX, A or AAAA DNS records
         if ($dnsRecords === []) {
+            if ($mxRecordsResult->withError()
+                && $aRecordsResult->withError()
+                && $aaaaRecordsResult->withError()
+            ) {
+                $this->error = new InvalidEmail(new UnableToGetDNSRecord(), '');
+                return false;
+            }
+
             $this->error = new InvalidEmail(new ReasonNoDNSRecord(), '');
             return false;
         }

--- a/src/Validation/DNSCheckValidation.php
+++ b/src/Validation/DNSCheckValidation.php
@@ -184,6 +184,11 @@ class DNSCheckValidation implements EmailValidation
         return $this->validateMxRecords($dnsRecords);
     }
 
+    /**
+     * @param array<array> $dnsRecords
+     *
+     * @return bool True if valid.
+     */
     private function validateMxRecords($dnsRecords): bool
     {
         // For each DNS record


### PR DESCRIPTION
Copied from https://github.com/egulias/EmailValidator/issues/408

----

I have a IONOS and google cloud server and some A records fail to resolve the `DNS_A + DNS_MX` part:

```bash
php -r 'require_once("vendor/autoload.php"); $dnsCheckValidation = new \Egulias\EmailValidator\Validation\DNSCheckValidation(); var_dump($dnsCheckValidation->isValid("somemail@adif.es", new \Egulias\EmailValidator\EmailLexer())); var_dump($dnsCheckValidation->getError());'
```

Locally all works like expected.

PS: Tried today a Hetzner Cloud server which has the same issue. I also tried directly the PHP:

```php
php -r 'var_dump(dns_get_record("adif.es", DNS_A + DNS_MX));'
```

And it fails. Did found out the used DNS and tried `dig` command which ends in:

```sh
dig @185.12.64.2 +short A adif.es
```

Goes into `;; connection timed out; no servers could be reache`

while over google it not errors just return nothing what is expected as only a `MX` record exists:

```sh
dig @8.8.8.8 +short A adif.es
```



